### PR TITLE
CI Nighly Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.0
+
 jobs:
   build:
     docker:
@@ -35,15 +36,19 @@ jobs:
           path: reports
       - store_artifacts:
           path: reports
+
 workflows:
   version: 2
-    nightly:
+  commit-workflow:
+    jobs:
+      - build
+  nightly-workflow:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 4 * * *"
           filters:
             branches:
-              only:
-                - master
+              only: master
+
     jobs:
       - build


### PR DESCRIPTION
This PR splits the CI jobs into two workflows so that we can have:
- builds when pushing commits to a branch
- a nightly build at [4AM](https://www.ted.com/talks/rives_on_4_a_m) on the `master` branch