### PR TITLE
Update link to CONTRIBUTE.md

### DIFF
--- a/.github/CONTRIBUTE.md
+++ b/.github/CONTRIBUTE.md
@@ -29,4 +29,4 @@ For the first line, try to be specific. e.g: "Ensure colony keys are unique" ins
 If you're adding or changing existing tests, they should go on the same commit.
 
 ## Code of Conduct
-Please note we have a [code of conduct](https://github.com/JoinColony/purser/blob/feature/add-docs/.github/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](https://github.com/JoinColony/purser/blob/master/.github/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We plan to add support more hardware wallets and other features that will make w
 
 We welcome all contributions to Purser. You can help by adding support for new wallet types, testing existing wallets, or improving the documentation.
 
-Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTING.md) for how to get started.
+Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTE.md) for how to get started.
 
 ### License
 

--- a/docs/_Docs_Contribute.md
+++ b/docs/_Docs_Contribute.md
@@ -33,4 +33,4 @@ For the first line, try to be specific. e.g: "Ensure colony keys are unique" ins
 If you're adding or changing existing tests, they should go on the same commit.
 
 ## Code of Conduct
-Please note we have a [code of conduct](https://github.com/JoinColony/purser/blob/feature/add-docs/.github/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](https://github.com/JoinColony/purser/blob/master/.github/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.

--- a/modules/node_modules/@colony/purser-core/README.md
+++ b/modules/node_modules/@colony/purser-core/README.md
@@ -26,7 +26,7 @@ You can find more in-depth description for this module's API in the [purser docs
 
 This package is part of the [purser monorepo](https://github.com/JoinColony/purser) package.
 
-Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTING.md) for how to get started.
+Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTE.md) for how to get started.
 
 ### License
 

--- a/modules/node_modules/@colony/purser-ledger/README.md
+++ b/modules/node_modules/@colony/purser-ledger/README.md
@@ -28,7 +28,7 @@ You can find more in-depth description for this module's API in the [purser docs
 
 This package is part of the [purser monorepo](https://github.com/JoinColony/purser) package.
 
-Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTING.md) for how to get started.
+Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTE.md) for how to get started.
 
 ### License
 

--- a/modules/node_modules/@colony/purser-metamask/README.md
+++ b/modules/node_modules/@colony/purser-metamask/README.md
@@ -26,7 +26,7 @@ You can find more in-depth description for this module's API in the [purser docs
 
 This package is part of the [purser monorepo](https://github.com/JoinColony/purser) package.
 
-Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTING.md) for how to get started.
+Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTE.md) for how to get started.
 
 ### License
 

--- a/modules/node_modules/@colony/purser-software/README.md
+++ b/modules/node_modules/@colony/purser-software/README.md
@@ -26,7 +26,7 @@ You can find more in-depth description for this module's API in the [purser docs
 
 This package is part of the [purser monorepo](https://github.com/JoinColony/purser) package.
 
-Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTING.md) for how to get started.
+Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTE.md) for how to get started.
 
 ### License
 

--- a/modules/node_modules/@colony/purser-trezor/README.md
+++ b/modules/node_modules/@colony/purser-trezor/README.md
@@ -28,7 +28,7 @@ You can find more in-depth description for this module's API in the [purser docs
 
 This package is part of the [purser monorepo](https://github.com/JoinColony/purser) package.
 
-Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTING.md) for how to get started.
+Please read our [Contributing Guidelines](https://github.com/JoinColony/purser/blob/master/.github/CONTRIBUTE.md) for how to get started.
 
 ### License
 


### PR DESCRIPTION
This PR updates the link from the various documentation documents inside the repo to the `CONTRIBUTE.md` file.

These links were either broken or used an outdated reference.