### PR TITLE
Manually update packages not handled by Greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "bn.js": "^4.11.8",
     "ethereumjs-tx": "^1.3.6",
     "ethereumjs-util": "^5.2.0",
-    "ethers": "^3.0.16",
+    "ethers": "^3.0.29",
     "hdkey": "^1.1.0",
     "lodash.isequal": "^4.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "5.0.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-config-prettier": "^3.0.0",
-    "eslint-plugin-flowtype": "^2.47.1",
+    "eslint-plugin-flowtype": "^2.50.1",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-prettier": "^2.5.0",
     "find-imports": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jest": "^23.5.0",
     "jest-junit": "^5.0.0",
     "jest-sandbox": "^1.1.1",
-    "lint-staged": "^7.0.0",
+    "lint-staged": "^7.3.0",
     "prettier": "^1.14.3",
     "regenerator-runtime": "^0.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jest-junit": "^5.0.0",
     "jest-sandbox": "^1.1.1",
     "lint-staged": "^7.0.0",
-    "prettier": "^1.10.2",
+    "prettier": "^1.14.3",
     "regenerator-runtime": "^0.12.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4747,9 +4747,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.10.2:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.6.tgz#00ae0b777ad92f81a9e7a1df2f0470b6dab0cb44"
+prettier@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
 
 pretty-format@^23.2.0:
   version "23.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,10 +714,6 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-root-path@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
-
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -3724,7 +3720,7 @@ jest-util@^23.4.0:
     slash "^1.0.0"
     source-map "^0.6.0"
 
-jest-validate@^23.0.0, jest-validate@^23.0.1:
+jest-validate@^23.0.1:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.2.0.tgz#67c8b909e11af1701765238894c67ac3291b195e"
   dependencies:
@@ -3940,11 +3936,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.2.0.tgz#bdf4bb7f2f37fe689acfaec9999db288a5b26888"
+lint-staged@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.3.0.tgz#90ff33e5ca61ed3dbac35b6f6502dbefdc0db58d"
   dependencies:
-    app-root-path "^2.0.1"
     chalk "^2.3.1"
     commander "^2.14.1"
     cosmiconfig "^5.0.2"
@@ -3954,7 +3949,7 @@ lint-staged@^7.0.0:
     find-parent-dir "^0.3.0"
     is-glob "^4.0.0"
     is-windows "^1.0.2"
-    jest-validate "^23.0.0"
+    jest-validate "^23.5.0"
     listr "^0.14.1"
     lodash "^4.17.5"
     log-symbols "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,9 +2228,9 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-flowtype@^2.47.1:
-  version "2.49.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz#ccca6ee5ba2027eb3ed36bc2ec8c9a842feee841"
+eslint-plugin-flowtype@^2.50.1:
+  version "2.50.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz#36d4c961ac8b9e9e1dc091d3fba0537dad34ae8a"
   dependencies:
     lodash "^4.17.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,9 +2375,9 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.2.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-ethers@^3.0.16:
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.24.tgz#e1f6328628440834740216aeb3f4a8460410ae5b"
+ethers@^3.0.29:
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.29.tgz#ce8139955b4ed44456eb6764b089bb117c86775d"
   dependencies:
     aes-js "3.0.0"
     bn.js "^4.4.0"


### PR DESCRIPTION
This PR updates the following dependencies, that were not automatically updated by GK:
- `eslint-plugin-flowtype` #133 
- `lint-staged` #135 
- `prettier` #134 
- `ethers` #136 

This is due to a `git commit` error happening in the CI build initiated by the `greenkeeper-lockfile-update` binary.

The fix for this will come in a separate PR

Resolves #133 
Resolves #134 
Resolves #135 
Resolves #136