### PR TITLE
Remove manual Greenkeeper lockfile update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,50 +1,6 @@
 version: 2.0
 
 jobs:
-  build-with-lockfile:
-    docker:
-      - image: circleci/node:8.10
-    parallelism: 2
-    working_directory: ~/purser
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-          - node-modules-{{ checksum "package.json" }}
-          - node-modules-
-      - run:
-          name: "Installing modules"
-          command: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: node-modules-{{ checksum "package.json" }}
-      - run:
-          name: "Updating lockfile"
-          command: yarn lockfile:update
-      - run:
-          name: "Checking correct types"
-          command: |
-            mkdir -p reports/flow
-            yarn flow:ci
-      - run:
-          name: "Linting code"
-          command: yarn lint:ci
-      - run:
-          name: "Running unit tests"
-          command: yarn test:ci
-          environment:
-            JEST_JUNIT_OUTPUT: "reports/jest/jest-results.xml"
-      - store_test_results:
-          path: reports
-      - store_artifacts:
-          path: reports
-      - run:
-          name: "Building library"
-          command: yarn build
-      - run:
-          name: "Uploading updated lockfile"
-          command: yarn lockfile:upload
   build:
     docker:
       - image: circleci/node:8.10
@@ -88,7 +44,7 @@ workflows:
   version: 2
   triggered-by-commit:
     jobs:
-      - build-with-lockfile
+      - build
   nightly-build:
     triggers:
       - schedule:

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watchAll --verbose",
     "test:coverage": "NODE_ENV=test jest --coverage",
-    "test:ci": "jest --clearCache && NODE_ENV=test jest --ci --bail --verbose=true --reporters='jest-junit'",
-    "lockfile:update": "greenkeeper-lockfile-update",
-    "lockfile:upload": "greenkeeper-lockfile-upload"
+    "test:ci": "jest --clearCache && NODE_ENV=test jest --ci --bail --verbose=true --reporters='jest-junit'"
   },
   "repository": {
     "type": "git",
@@ -71,7 +69,6 @@
     "flow-copy-source": "^2.0.0",
     "fs-extra": "^7.0.0",
     "glow": "^1.2.2",
-    "greenkeeper-lockfile": "1",
     "husky": "^0.14.3",
     "jest": "^23.5.0",
     "jest-junit": "^5.0.0",
@@ -81,9 +78,9 @@
     "regenerator-runtime": "^0.12.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "@ledgerhq/hw-app-eth": "^4.19.0",
     "@ledgerhq/hw-transport-u2f": "^4.20.0",
-    "@babel/runtime": "^7.0.0",
     "bip32-path": "^0.4.2",
     "bn.js": "^4.11.8",
     "ethereumjs-tx": "^1.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,14 +2851,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-greenkeeper-lockfile@1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-1.15.1.tgz#289728213f8d4731596fdb011e3c6eb24ee96a73"
-  dependencies:
-    lodash "^4.17.4"
-    require-relative "^0.8.7"
-    semver "^5.3.0"
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -5057,10 +5049,6 @@ require-directory@^2.1.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-
-require-relative@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR removes the `greenkeeper-lockfile` package and it's related CI build job.

This is because Greenkeeper _(now)_ supports this natively for public packages: https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0

This should now fix all the latest greenkeeper failed updates.