### PR TITLE
Add correct modules named exports

### DIFF
--- a/modules/node_modules/@colony/purser-core/index.js
+++ b/modules/node_modules/@colony/purser-core/index.js
@@ -20,4 +20,15 @@ const coreModule: Object = {
   GenericWallet,
 };
 
+export {
+  helpers,
+  defaults,
+  validators,
+  normalizers,
+  messages,
+  types,
+  utils,
+  GenericWallet,
+};
+
 export default coreModule;

--- a/modules/node_modules/@colony/purser-ledger/index.js
+++ b/modules/node_modules/@colony/purser-ledger/index.js
@@ -14,99 +14,96 @@ import { staticMethods as messages } from './messages';
 
 import type { LedgerInstanceType } from './flowtypes';
 
-const ledgerWallet: Object = Object.assign(
-  {},
-  {
-    /**
-     * Open a new wallet from the public key and chain code, which are received
-     * form the Ledger device (after unlocking it and entering the Ethereum app)
-     *
-     * @method open
-     *
-     * @param {number} addressCount the number of extra addresses to generate from the derivation path
-     * @param {number} chainId The id of the network to use, defaults to mainnet (1)
-     *
-     * The above param is sent in as a prop of an {WalletArgumentsType} object.
-     *
-     * @return {WalletType} The wallet object resulted by instantiating the class
-     * (Object is wrapped in a promise).
-     *
+/**
+ * Open a new wallet from the public key and chain code, which are received
+ * form the Ledger device (after unlocking it and entering the Ethereum app)
+ *
+ * @method open
+ *
+ * @param {number} addressCount the number of extra addresses to generate from the derivation path
+ * @param {number} chainId The id of the network to use, defaults to mainnet (1)
+ *
+ * The above param is sent in as a prop of an {WalletArgumentsType} object.
+ *
+ * @return {WalletType} The wallet object resulted by instantiating the class
+ * (Object is wrapped in a promise).
+ *
+ */
+export const open = async (
+  argumentObject: WalletArgumentsType = {},
+): Promise<LedgerWallet | void> => {
+  /*
+   * Validate the trasaction's object input
+   */
+  userInputValidator({
+    firstArgument: argumentObject,
+  });
+  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  /*
+   * @TODO Reduce code repetition
+   * By moving this inside a helper. This same patter will be used on the
+   * trezor wallet as well.
+   *
+   * If we're on a testnet set the coin type id to `1`
+   * This will be used in the derivation path
+   */
+  const coinType: number =
+    chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
+  /*
+   * Get to root derivation path based on the coin type.
+   *
+   * Based on this, we will then derive all the needed address indexes
+   * (inside the class constructor)
+   */
+  const rootDerivationPath: string = derivationPathSerializer({
+    coinType,
+  });
+  try {
+    const ledger: LedgerInstanceType = await ledgerConnection();
+    /*
+     * Get the harware wallet's root public key and chain code, to use
+     * for deriving the rest of the accounts
      */
-    open: async (
-      argumentObject: WalletArgumentsType = {},
-    ): Promise<LedgerWallet | void> => {
+    const { publicKey, chainCode } = await ledger.getAddress(
       /*
-       * Validate the trasaction's object input
-       */
-      userInputValidator({
-        firstArgument: argumentObject,
-      });
-      const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
-      /*
-       * @TODO Reduce code repetition
-       * By moving this inside a helper. This same patter will be used on the
-       * trezor wallet as well.
+       * @NOTE Ledger requires a derivation path containing only the account value
+       * No change and index
        *
-       * If we're on a testnet set the coin type id to `1`
-       * This will be used in the derivation path
+       * If you want to prompt the user on the device, set the second argument
+       * as true.
        */
-      const coinType: number =
-        chainId === NETWORK_IDS.HOMESTEAD
-          ? PATH.COIN_MAINNET
-          : PATH.COIN_TESTNET;
+      rootDerivationPath,
+      false,
+      true,
+    );
+    const walletInstance: LedgerWallet = new LedgerWallet({
+      publicKey,
+      chainCode,
       /*
-       * Get to root derivation path based on the coin type.
+       * Since we need to strip out the change values when opening the Ledger
+       * wallet, we need to remove the post-pending slash. This way, the final
+       * derivation path gets concatenated correctly.
        *
-       * Based on this, we will then derive all the needed address indexes
-       * (inside the class constructor)
+       * The only alternative would be to re-generate the derivation path inside
+       * the class's constructor, but that would mean extra computational resources.
        */
-      const rootDerivationPath: string = derivationPathSerializer({
-        coinType,
-      });
-      try {
-        const ledger: LedgerInstanceType = await ledgerConnection();
-        /*
-         * Get the harware wallet's root public key and chain code, to use
-         * for deriving the rest of the accounts
-         */
-        const { publicKey, chainCode } = await ledger.getAddress(
-          /*
-           * @NOTE Ledger requires a derivation path containing only the account value
-           * No change and index
-           *
-           * If you want to prompt the user on the device, set the second argument
-           * as true.
-           */
-          rootDerivationPath,
-          false,
-          true,
-        );
-        const walletInstance: LedgerWallet = new LedgerWallet({
-          publicKey,
-          chainCode,
-          /*
-           * Since we need to strip out the change values when opening the Ledger
-           * wallet, we need to remove the post-pending slash. This way, the final
-           * derivation path gets concatenated correctly.
-           *
-           * The only alternative would be to re-generate the derivation path inside
-           * the class's constructor, but that would mean extra computational resources.
-           */
-          rootDerivationPath,
-          addressCount,
-          chainId,
-        });
-        return walletInstance;
-      } catch (caughtError) {
-        return handleLedgerConnectionError(
-          caughtError,
-          `${messages.userExportGenericError}: ${rootDerivationPath} ${
-            caughtError.message
-          }`,
-        );
-      }
-    },
-  },
-);
+      rootDerivationPath,
+      addressCount,
+      chainId,
+    });
+    return walletInstance;
+  } catch (caughtError) {
+    return handleLedgerConnectionError(
+      caughtError,
+      `${messages.userExportGenericError}: ${rootDerivationPath} ${
+        caughtError.message
+      }`,
+    );
+  }
+};
+
+const ledgerWallet: Object = {
+  open,
+};
 
 export default ledgerWallet;

--- a/modules/node_modules/@colony/purser-metamask/index.js
+++ b/modules/node_modules/@colony/purser-metamask/index.js
@@ -11,36 +11,39 @@ import { staticMethods as messages } from './messages';
 
 import type { MetamaskInpageProviderType } from './flowtypes';
 
+/**
+ * Open the Metamask Wallet instance
+ *
+ * @method open
+ *
+ * @return {WalletType} The wallet object resulted by instantiating the class
+ * (Object is wrapped in a promise).
+ */
+export const open = async (): Promise<MetamaskWallet> =>
+  methodCaller(() => {
+    const {
+      publicConfigStore: { _state: state },
+    }: () => MetamaskInpageProviderType = getInpageProvider();
+    return new MetamaskWallet({
+      address: state.selectedAddress,
+    });
+  }, messages.metamaskNotAvailable);
+/**
+ * Check if Metamask's injected web3 proxy instance is available in the
+ * global object.
+ *
+ * Makes use of the `detect()` helper, basically it's a wrapper
+ * that exposes it from the module.
+ *
+ * @method detect
+ *
+ * @return {boolean} Only returns true if it's available, otherwise it will throw.
+ */
+export const detect = async (): Promise<boolean> => detectHelper();
+
 const metamaskWallet: Object = {
-  /**
-   * Open the Metamask Wallet instance
-   *
-   * @method open
-   *
-   * @return {WalletType} The wallet object resulted by instantiating the class
-   * (Object is wrapped in a promise).
-   */
-  open: async (): Promise<MetamaskWallet> =>
-    methodCaller(() => {
-      const {
-        publicConfigStore: { _state: state },
-      }: () => MetamaskInpageProviderType = getInpageProvider();
-      return new MetamaskWallet({
-        address: state.selectedAddress,
-      });
-    }, messages.metamaskNotAvailable),
-  /**
-   * Check if Metamask's injected web3 proxy instance is available in the
-   * global object.
-   *
-   * Makes use of the `detect()` helper, basically it's a wrapper
-   * that exposes it from the module.
-   *
-   * @method detect
-   *
-   * @return {boolean} Only returns true if it's available, otherwise it will throw.
-   */
-  detect: async (): Promise<boolean> => detectHelper(),
+  open,
+  detect,
 };
 
 export default metamaskWallet;

--- a/modules/node_modules/@colony/purser-software/index.js
+++ b/modules/node_modules/@colony/purser-software/index.js
@@ -24,194 +24,195 @@ import SoftwareWallet from './class';
 import { REQUIRED_PROPS as REQUIRED_PROPS_SOFTWARE } from './defaults';
 import { staticMethods as messages } from './messages';
 
-const softwareWallet: Object = Object.assign(
-  {},
-  {
-    /**
-     * Open an existing wallet
-     * Using either `mnemonic`, `private key` or `encrypted keystore`
-     *
-     * This will try to extract the private key from a mnemonic (if available),
-     * and create a new SoftwareWallet instance using whichever key is available.
-     * (the on passed in or the one extracted from the mnemonic).
-     *
-     * @TODO Reduce code repetition
-     *
-     * With some clever refactoring we might be able to only call the SoftwareWallet
-     * constructor a single time for all three methods of opening the wallet
-     *
-     * @method open
-     *
-     * @param {string} password Optional password used to generate an encrypted keystore
-     * @param {string} privateKey Private key to open the wallet with
-     * @param {string} mnemonic Mnemonic string to open the wallet with
-     * @param {string} keystore JSON formatted keystore string to open the wallet with.
-     * Only works if you also send in a password
-     * @param {number} chainId The id of the network to use, defaults to mainnet (1)
-     *
-     * All the above params are sent in as props of an {WalletArgumentsType} object.
-     *
-     * @return {WalletType} A new wallet object (or undefined) if somehwere along
-     * the line an error is thrown.
+/**
+ * Open an existing wallet
+ * Using either `mnemonic`, `private key` or `encrypted keystore`
+ *
+ * This will try to extract the private key from a mnemonic (if available),
+ * and create a new SoftwareWallet instance using whichever key is available.
+ * (the on passed in or the one extracted from the mnemonic).
+ *
+ * @TODO Reduce code repetition
+ *
+ * With some clever refactoring we might be able to only call the SoftwareWallet
+ * constructor a single time for all three methods of opening the wallet
+ *
+ * @method open
+ *
+ * @param {string} password Optional password used to generate an encrypted keystore
+ * @param {string} privateKey Private key to open the wallet with
+ * @param {string} mnemonic Mnemonic string to open the wallet with
+ * @param {string} keystore JSON formatted keystore string to open the wallet with.
+ * Only works if you also send in a password
+ * @param {number} chainId The id of the network to use, defaults to mainnet (1)
+ *
+ * All the above params are sent in as props of an {WalletArgumentsType} object.
+ *
+ * @return {WalletType} A new wallet object (or undefined) if somehwere along
+ * the line an error is thrown.
+ */
+export const open = async (
+  argumentObject: WalletArgumentsType = {},
+): Promise<SoftwareWallet | void> => {
+  /*
+   * Validate the trasaction's object input
+   */
+  userInputValidator({
+    firstArgument: argumentObject,
+    requiredEither: REQUIRED_PROPS_SOFTWARE.OPEN_WALLET,
+  });
+  const {
+    password,
+    privateKey,
+    mnemonic,
+    keystore,
+    chainId = NETWORK_IDS.HOMESTEAD,
+  } = argumentObject;
+  let extractedPrivateKey: string;
+  /*
+   * @TODO Re-add use ability to control derivation path
+   * When opening the wallet. But only if this proves to be a needed feature.
+   */
+  const derivationPath: string = derivationPathSerializer({
+    change: PATH.CHANGE,
+    addressIndex: PATH.INDEX,
+  });
+  try {
+    /*
+     * @TODO Detect if existing but not valid keystore, and warn the user
      */
-    open: async (
-      argumentObject: WalletArgumentsType = {},
-    ): Promise<SoftwareWallet | void> => {
+    if (keystore && EthersWallet.isEncryptedWallet(keystore) && password) {
+      const keystoreWallet: Object =
+        /*
+         * Prettier suggests changes that would always result in eslint
+         * breaking. This must be one of the edge cases of prettier.
+         *
+         * Nevertheless, by inserting this comment, it works :)
+         */
+        await EthersWallet.fromEncryptedWallet(keystore, password);
       /*
-       * Validate the trasaction's object input
+       * Set the keystore and password props on the instance object.
+       *
+       * So that we can make use of them inside the SoftwareWallet
+       * constructor, as the Ethers Wallet instance object will
+       * be passed down.
+       *
+       * @TODO Better passing of values
+       *
+       * This needs to be refactored to pass values to the SoftwareWallet
+       * class in a less repetitious way
        */
-      userInputValidator({
-        firstArgument: argumentObject,
-        requiredEither: REQUIRED_PROPS_SOFTWARE.OPEN_WALLET,
-      });
-      const {
+      keystoreWallet.keystore = keystore;
+      keystoreWallet.password = password;
+      keystoreWallet.chainId = chainId;
+      return new SoftwareWallet(keystoreWallet);
+    }
+    /*
+     * @TODO Detect if existing but not valid mnemonic, and warn the user
+     */
+    if (mnemonic && HDNode.isValidMnemonic(mnemonic)) {
+      const mnemonicWallet: Object = HDNode.fromMnemonic(mnemonic).derivePath(
+        derivationPath,
+      );
+      extractedPrivateKey = mnemonicWallet.privateKey;
+    }
+    /*
+     * @TODO Detect if existing but not valid private key, and warn the user
+     */
+    const privateKeyWallet = new EthersWallet(
+      privateKey || extractedPrivateKey,
+    );
+    /*
+     * Set the mnemonic and password props on the instance object.
+     *
+     * So that we can make use of them inside the SoftwareWallet
+     * constructor, as the Ethers Wallet instance object will
+     * be passed down.
+     *
+     * @TODO Better passing of values
+     *
+     * This needs to be refactored to pass values to the SoftwareWallet
+     * class in a less repetitious way
+     */
+    privateKeyWallet.mnemonic = mnemonic;
+    privateKeyWallet.password = password;
+    privateKeyWallet.chainId = chainId;
+    return new SoftwareWallet(privateKeyWallet);
+  } catch (caughtError) {
+    throw new Error(
+      `${messages.open} ${objectToErrorString({
         password,
         privateKey,
         mnemonic,
         keystore,
-        chainId = NETWORK_IDS.HOMESTEAD,
-      } = argumentObject;
-      let extractedPrivateKey: string;
-      /*
-       * @TODO Re-add use ability to control derivation path
-       * When opening the wallet. But only if this proves to be a needed feature.
-       */
-      const derivationPath: string = derivationPathSerializer({
-        change: PATH.CHANGE,
-        addressIndex: PATH.INDEX,
+      })} Error: ${caughtError.message}`,
+    );
+  }
+};
+
+/**
+ * Create a new wallet.
+ *
+ * This will use EtherWallet's `createRandom()` (with defaults and entropy)
+ * and use the resulting private key to instantiate a new SoftwareWallet.
+ *
+ * @method create
+ *
+ * @param {Uint8Array} entropy An unsigned 8bit integer Array to provide extra randomness
+ * @param {string} password Optional password used to generate an encrypted keystore
+ * @param {number} chainId The id of the network to use, defaults to mainnet (1)
+ *
+ * All the above params are sent in as props of an {WalletArgumentsType} object.
+ *
+ * @return {WalletType} A new wallet object
+ */
+export const create = async (
+  argumentObject: WalletArgumentsType = {},
+): Promise<SoftwareWallet | void> => {
+  /*
+   * Validate the trasaction's object input
+   */
+  userInputValidator({
+    firstArgument: argumentObject,
+  });
+  const {
+    password,
+    entropy = getRandomValues(new Uint8Array(65536)),
+    chainId = NETWORK_IDS.HOMESTEAD,
+  } = argumentObject;
+  let basicWallet: WalletObjectType;
+  try {
+    if (!entropy || (entropy && !(entropy instanceof Uint8Array))) {
+      warning(messages.noEntrophy);
+      basicWallet = EthersWallet.createRandom();
+    } else {
+      basicWallet = EthersWallet.createRandom({
+        extraEntropy: entropy,
       });
-      try {
-        /*
-         * @TODO Detect if existing but not valid keystore, and warn the user
-         */
-        if (keystore && EthersWallet.isEncryptedWallet(keystore) && password) {
-          const keystoreWallet: Object =
-            /*
-             * Prettier suggests changes that would always result in eslint
-             * breaking. This must be one of the edge cases of prettier.
-             *
-             * Nevertheless, by inserting this comment, it works :)
-             */
-            await EthersWallet.fromEncryptedWallet(keystore, password);
-          /*
-           * Set the keystore and password props on the instance object.
-           *
-           * So that we can make use of them inside the SoftwareWallet
-           * constructor, as the Ethers Wallet instance object will
-           * be passed down.
-           *
-           * @TODO Better passing of values
-           *
-           * This needs to be refactored to pass values to the SoftwareWallet
-           * class in a less repetitious way
-           */
-          keystoreWallet.keystore = keystore;
-          keystoreWallet.password = password;
-          keystoreWallet.chainId = chainId;
-          return new SoftwareWallet(keystoreWallet);
-        }
-        /*
-         * @TODO Detect if existing but not valid mnemonic, and warn the user
-         */
-        if (mnemonic && HDNode.isValidMnemonic(mnemonic)) {
-          const mnemonicWallet: Object = HDNode.fromMnemonic(
-            mnemonic,
-          ).derivePath(derivationPath);
-          extractedPrivateKey = mnemonicWallet.privateKey;
-        }
-        /*
-         * @TODO Detect if existing but not valid private key, and warn the user
-         */
-        const privateKeyWallet = new EthersWallet(
-          privateKey || extractedPrivateKey,
-        );
-        /*
-         * Set the mnemonic and password props on the instance object.
-         *
-         * So that we can make use of them inside the SoftwareWallet
-         * constructor, as the Ethers Wallet instance object will
-         * be passed down.
-         *
-         * @TODO Better passing of values
-         *
-         * This needs to be refactored to pass values to the SoftwareWallet
-         * class in a less repetitious way
-         */
-        privateKeyWallet.mnemonic = mnemonic;
-        privateKeyWallet.password = password;
-        privateKeyWallet.chainId = chainId;
-        return new SoftwareWallet(privateKeyWallet);
-      } catch (caughtError) {
-        throw new Error(
-          `${messages.open} ${objectToErrorString({
-            password,
-            privateKey,
-            mnemonic,
-            keystore,
-          })} Error: ${caughtError.message}`,
-        );
-      }
-    },
-    /**
-     * Create a new wallet.
+    }
+    /*
+     * Set the password prop on the instance object.
      *
-     * This will use EtherWallet's `createRandom()` (with defaults and entropy)
-     * and use the resulting private key to instantiate a new SoftwareWallet.
+     * So that we can make use of them inside the SoftwareWallet
+     * constructor, as the Ethers Wallet instance object will
+     * be passed down.
      *
-     * @method create
+     * @TODO Better passing of values
      *
-     * @param {Uint8Array} entropy An unsigned 8bit integer Array to provide extra randomness
-     * @param {string} password Optional password used to generate an encrypted keystore
-     * @param {number} chainId The id of the network to use, defaults to mainnet (1)
-     *
-     * All the above params are sent in as props of an {WalletArgumentsType} object.
-     *
-     * @return {WalletType} A new wallet object
+     * This needs to be refactored to pass values to the SoftwareWallet
+     * class in a less repetitious way
      */
-    create: async (
-      argumentObject: WalletArgumentsType = {},
-    ): Promise<SoftwareWallet | void> => {
-      /*
-       * Validate the trasaction's object input
-       */
-      userInputValidator({
-        firstArgument: argumentObject,
-      });
-      const {
-        password,
-        entropy = getRandomValues(new Uint8Array(65536)),
-        chainId = NETWORK_IDS.HOMESTEAD,
-      } = argumentObject;
-      let basicWallet: WalletObjectType;
-      try {
-        if (!entropy || (entropy && !(entropy instanceof Uint8Array))) {
-          warning(messages.noEntrophy);
-          basicWallet = EthersWallet.createRandom();
-        } else {
-          basicWallet = EthersWallet.createRandom({
-            extraEntropy: entropy,
-          });
-        }
-        /*
-         * Set the password prop on the instance object.
-         *
-         * So that we can make use of them inside the SoftwareWallet
-         * constructor, as the Ethers Wallet instance object will
-         * be passed down.
-         *
-         * @TODO Better passing of values
-         *
-         * This needs to be refactored to pass values to the SoftwareWallet
-         * class in a less repetitious way
-         */
-        basicWallet.password = password;
-        basicWallet.chainId = chainId;
-        return new SoftwareWallet(basicWallet);
-      } catch (caughtError) {
-        throw new Error(`${messages.create} Error: ${caughtError.message}`);
-      }
-    },
-  },
-);
+    basicWallet.password = password;
+    basicWallet.chainId = chainId;
+    return new SoftwareWallet(basicWallet);
+  } catch (caughtError) {
+    throw new Error(`${messages.create} Error: ${caughtError.message}`);
+  }
+};
+
+const softwareWallet: Object = {
+  open,
+  create,
+};
 
 export default softwareWallet;

--- a/modules/node_modules/@colony/purser-trezor/index.js
+++ b/modules/node_modules/@colony/purser-trezor/index.js
@@ -18,101 +18,98 @@ import { staticMethodsMessages as messages } from './messages';
 import { STD_ERRORS } from './defaults';
 import { PAYLOAD_XPUB } from './payloads';
 
-const trezorWallet: Object = Object.assign(
-  {},
-  {
-    /**
-     * Open a new wallet from the public key and chain code, which are received
-     * form the Trezor service after interacting (confirming) with the hardware
-     * in real life.
-     *
-     * @method open
-     *
-     * @param {number} addressCount the number of extra addresses to generate from the derivation path
-     * @param {number} chainId The id of the network to use, defaults to mainnet (1)
-     *
-     * The above param is sent in as a prop of an {WalletArgumentsType} object.
-     *
-     * @return {WalletType} The wallet object resulted by instantiating the class
-     * (Object is wrapped in a promise).
-     *
+/**
+ * Open a new wallet from the public key and chain code, which are received
+ * form the Trezor service after interacting (confirming) with the hardware
+ * in real life.
+ *
+ * @method open
+ *
+ * @param {number} addressCount the number of extra addresses to generate from the derivation path
+ * @param {number} chainId The id of the network to use, defaults to mainnet (1)
+ *
+ * The above param is sent in as a prop of an {WalletArgumentsType} object.
+ *
+ * @return {WalletType} The wallet object resulted by instantiating the class
+ * (Object is wrapped in a promise).
+ *
+ */
+export const open = async (
+  argumentObject: WalletArgumentsType = {},
+): Promise<TrezorWallet | void> => {
+  /*
+   * Validate the trasaction's object input
+   */
+  userInputValidator({
+    firstArgument: argumentObject,
+  });
+  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  /*
+   * @TODO Reduce code repetition
+   * By moving this inside a helper. This same patter will be used on the
+   * ledger wallet as well.
+   *
+   * If we're on a testnet set the coin type id to `1`
+   * This will be used in the derivation path
+   */
+  const coinType: number =
+    chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
+  /*
+   * Get to root derivation path based on the coin type.
+   *
+   * Based on this, we will then derive all the needed address indexes
+   * (inside the class constructor)
+   */
+  const rootDerivationPath: string = derivationPathSerializer({
+    change: PATH.CHANGE,
+    coinType,
+  });
+  /*
+   * Modify the default payload to overwrite the path with the new
+   * coin type id derivation
+   */
+  const modifiedPayloadObject: Object = Object.assign({}, PAYLOAD_XPUB, {
+    path: fromString(rootDerivationPath, true).toPathArray(),
+  });
+  /*
+   * We need to catch the cancelled error since it's part of a normal user workflow
+   */
+  try {
+    /*
+     * Get the harware wallet's public key and chain code, to use for deriving
+     * the rest of the accounts
      */
-    open: async (
-      argumentObject: WalletArgumentsType = {},
-    ): Promise<TrezorWallet | void> => {
-      /*
-       * Validate the trasaction's object input
-       */
-      userInputValidator({
-        firstArgument: argumentObject,
-      });
-      const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
-      /*
-       * @TODO Reduce code repetition
-       * By moving this inside a helper. This same patter will be used on the
-       * ledger wallet as well.
-       *
-       * If we're on a testnet set the coin type id to `1`
-       * This will be used in the derivation path
-       */
-      const coinType: number =
-        chainId === NETWORK_IDS.HOMESTEAD
-          ? PATH.COIN_MAINNET
-          : PATH.COIN_TESTNET;
-      /*
-       * Get to root derivation path based on the coin type.
-       *
-       * Based on this, we will then derive all the needed address indexes
-       * (inside the class constructor)
-       */
-      const rootDerivationPath: string = derivationPathSerializer({
-        change: PATH.CHANGE,
-        coinType,
-      });
-      /*
-       * Modify the default payload to overwrite the path with the new
-       * coin type id derivation
-       */
-      const modifiedPayloadObject: Object = Object.assign({}, PAYLOAD_XPUB, {
-        path: fromString(rootDerivationPath, true).toPathArray(),
-      });
-      /*
-       * We need to catch the cancelled error since it's part of a normal user workflow
-       */
-      try {
-        /*
-         * Get the harware wallet's public key and chain code, to use for deriving
-         * the rest of the accounts
-         */
-        const { publicKey, chainCode } = await payloadListener({
-          payload: modifiedPayloadObject,
-        });
-        const walletInstance: TrezorWallet = new TrezorWallet({
-          publicKey,
-          chainCode,
-          rootDerivationPath,
-          addressCount,
-          chainId,
-        });
-        return walletInstance;
-      } catch (caughtError) {
-        /*
-         * Don't throw an error if the user cancelled
-         */
-        if (caughtError.message === STD_ERRORS.CANCEL_ACC_EXPORT) {
-          return warning(messages.userExportCancel);
-        }
-        /*
-         * But throw otherwise, so we can see what's going on
-         */
-        throw new Error(
-          `${messages.userExportGenericError}: ${objectToErrorString(
-            modifiedPayloadObject,
-          )} ${caughtError.message}`,
-        );
-      }
-    },
-  },
-);
+    const { publicKey, chainCode } = await payloadListener({
+      payload: modifiedPayloadObject,
+    });
+    const walletInstance: TrezorWallet = new TrezorWallet({
+      publicKey,
+      chainCode,
+      rootDerivationPath,
+      addressCount,
+      chainId,
+    });
+    return walletInstance;
+  } catch (caughtError) {
+    /*
+     * Don't throw an error if the user cancelled
+     */
+    if (caughtError.message === STD_ERRORS.CANCEL_ACC_EXPORT) {
+      return warning(messages.userExportCancel);
+    }
+    /*
+     * But throw otherwise, so we can see what's going on
+     */
+    throw new Error(
+      `${messages.userExportGenericError}: ${objectToErrorString(
+        modifiedPayloadObject,
+      )} ${caughtError.message}`,
+    );
+  }
+};
+
+const trezorWallet: Object = {
+  open,
+};
 
 export default trezorWallet;


### PR DESCRIPTION
This PR fixes an oversight with the initial release of the library, which only had `default` exports for the index files.

This PR changes all modules `index.js` file to also add a named export to each exposed method, alongside the `default` one.

Modules:
- [x] `purser-core`
- [x] `purser-ledger`
- [x] `purser-metamask`
- [x] `purser-software`
- [x] `purser-trezor`

_**Note:** This does not require a documentation update, as all the docs already assume named exports exist_