### PR TITLE
Common Wallet Interface Docs Spelling Fix

### DIFF
--- a/docs/_Interface_Common_Wallet_Interface.md
+++ b/docs/_Interface_Common_Wallet_Interface.md
@@ -24,7 +24,7 @@ WalletInstance {
   /*
    * Methods
    */
-  setDefaulAddress(addressIndex: Number): Promise<Boolean>,
+  setDefaultAddress(addressIndex: Number): Promise<Boolean>,
   sign(transactionObject: Object): Promise<String>
   signMessage(messageObject: Object): Promise<String>
   verifyMessage(verificationObject: Object): Promise<Boolean>


### PR DESCRIPTION
This PR fixes a small spelling mistake inside the [Common Wallet Interface docs](https://docs.colony.io/purser/interface-common-wallet-interface/) regarding the `setDefaultAddress()` method.