### PR TITLE
Refactor transaction signing restrictions

### DIFF
--- a/docs/_Interface_Common_Wallet_Interface.md
+++ b/docs/_Interface_Common_Wallet_Interface.md
@@ -328,25 +328,31 @@ transactionObject {
   gasLimit: bigNumber // The gas limit you want for this transaction, as an instance of bigNumber. Defaults to 21000
   chainId: Number // The chain id where the transaction is going to be sent. Defaults to 1.
   nonce: Number // The nonce of the transaction. Defaults to 0.
-  to: String // The destination address to send the transaction to, as a hex String. This is the only REQUIRED prop by this library
+  to: String // The destination address to send the transaction to, as a hex String. If you deploy a new contract, you must omit this prop.
   value: bigNumber // The value you want to send to the destination address, in WEI, as an instance of bigNumber. Defaults to 1 WEI
-  inputData: String // The additional input data to send in the transaction, as a hex String. Defaults to `0x00`
+  inputData: String // The additional input data to send in the transaction, as a hex String. Defaults to ''
 }
 ```
 
+**Contract deployment:**
+
+To create and then sign a transaction intended to deploy a contract you need to omit the destination address field _(`to` prop)_. The sign method expects this and will not validate against it.
+
+_**Note**: While all other wallet types allow you to pass in an empty `inputData` field (not that it would be very useful), Trezor requires you to specifically set it. So you won't be able to sign a contract deployment transaction without also setting the transaction data._
+
 **Usage:**
 ```js
-import { open } from '@colony/purser-trezor';
+import { open } from '@colony/purser-software';
 
-const trezorWallet = await open();
+const softwareWallet = await open({ mnemonic: 'load blush ... sheriff surge' });
 
-const transactionSignature = await trezorWallet.sign({ to: '0x3953...a4C1' }); // 0xF990...8d91
+const transactionSignature = await softwareWallet.sign({ to: '0x3953...a4C1' }); // 0xF990...8d91
 ```
 ```js
-import { open } from '@colony/purser-trezor';
+import { open } from '@colony/purser-ledger';
 import { bigNumber } from '@colony/purser-core/utils';
 
-const trezorWallet = await open();
+const ledgerWallet = await open();
 
 const transaction = {
   gasPrice: bigNumber('0.00000001').toWei(),
@@ -358,7 +364,21 @@ const transaction = {
   inputData: '0x00',
 };
 
-const transactionSignature = await trezorWallet.sign(transaction); // 0xf849...5681
+const transactionSignature = await ledgerWallet.sign(transaction); // 0xf849...5681
+```
+Deploy a contract:
+```js
+import { open } from '@colony/purser-trezor';
+import { bigNumber } from '@colony/purser-core/utils';
+
+const trezorWallet = await open();
+
+// omit the 'to' prop
+const newContractTransaction = {
+  inputData: '0x00',
+};
+
+const transactionSignature = await trezorWallet.sign(newContractTransaction); // 0xf849...993a
 ```
 
 ### `signMessage()`

--- a/modules/node_modules/@colony/purser-core/defaults.js
+++ b/modules/node_modules/@colony/purser-core/defaults.js
@@ -133,15 +133,6 @@ export const NETWORK_IDS: Object = {
  * Prop names used to validate user input against
  */
 export const REQUIRED_PROPS: Object = {
-  /*
-   * @NOTE SIGN_TRANSACTION default value deprecation
-   * The transactions signature object requirements have been dropped (with the
-   * exception of Trezor) so this default will be removed once every module has
-   * been migrated
-   *
-   * @TODO Remove deprecated SIGN_TRANSACTION value
-   */
-  SIGN_TRANSACTION: ['to', 'nonce', 'value'],
   SIGN_MESSAGE: ['message'],
   VERIFY_MESSAGE: ['message', 'signature'],
 };

--- a/modules/node_modules/@colony/purser-core/defaults.js
+++ b/modules/node_modules/@colony/purser-core/defaults.js
@@ -133,6 +133,14 @@ export const NETWORK_IDS: Object = {
  * Prop names used to validate user input against
  */
 export const REQUIRED_PROPS: Object = {
+  /*
+   * @NOTE SIGN_TRANSACTION default value deprecation
+   * The transactions signature object requirements have been dropped (with the
+   * exception of Trezor) so this default will be removed once every module has
+   * been migrated
+   *
+   * @TODO Remove deprecated SIGN_TRANSACTION value
+   */
   SIGN_TRANSACTION: ['to', 'nonce', 'value'],
   SIGN_MESSAGE: ['message'],
   VERIFY_MESSAGE: ['message', 'signature'],

--- a/modules/node_modules/@colony/purser-core/flowtypes.js
+++ b/modules/node_modules/@colony/purser-core/flowtypes.js
@@ -20,11 +20,11 @@ export type DerivationPathDefaultType = {
 };
 
 export type TransactionObjectType = {
-  chainId?: number,
+  chainId: number,
   gasPrice: string,
   gasLimit: string,
   nonce: number,
-  to: string,
+  to?: string,
   value: string,
   inputData: string,
 };

--- a/modules/node_modules/@colony/purser-core/helpers.js
+++ b/modules/node_modules/@colony/purser-core/helpers.js
@@ -326,8 +326,8 @@ export const userInputValidator = ({
   requiredAll = [],
 }: {
   firstArgument: Object,
-  requiredAll?: Array<string>,
-  requiredEither?: Array<string>,
+  requiredAll?: Array<String>,
+  requiredEither?: Array<String>,
 } = {}): void => {
   const { userInputValidator: messages } = helperMessages;
   /*

--- a/modules/node_modules/@colony/purser-core/helpers.js
+++ b/modules/node_modules/@colony/purser-core/helpers.js
@@ -223,9 +223,6 @@ export const transactionObjectValidator = ({
   gasLimit = bigNumber(TRANSACTION.GAS_LIMIT),
   chainId = TRANSACTION.CHAIN_ID,
   nonce = TRANSACTION.NONCE,
-  /*
-   * The only one prop value actually required to be passed in by the user
-   */
   to,
   value = bigNumber(TRANSACTION.VALUE),
   inputData = TRANSACTION.INPUT_DATA,
@@ -247,9 +244,12 @@ export const transactionObjectValidator = ({
    */
   safeIntegerValidator(nonce);
   /*
-   * Check if the address (`to` prop) is in the correct format
+   * Only check if the address (`to` prop) is in the correct
+   * format, if one was provided in the initial transaction object
    */
-  addressValidator(to);
+  if (typeof to !== 'undefined') {
+    addressValidator(to);
+  }
   /*
    * Check that the value is a big number
    */

--- a/modules/node_modules/@colony/purser-core/messages.js
+++ b/modules/node_modules/@colony/purser-core/messages.js
@@ -75,7 +75,7 @@ export const helpers: Object = {
   },
   userInputValidator: {
     argumentsFormatExplanation:
-      "All user facing methods exposed by this library (from a Module or from a Wallet instance object) take they're arguments as props of an Object. Each method has it's own required or optional props that it expects. Please consult the documentation for each indivial's method call details.",
+      "All user facing methods exposed by this library (from a Module or from a Wallet instance object) take they're arguments as props of an Object. Each method has it's own required or optional props that it expects. Please consult the documentation about each individual method call.",
     notObject:
       "The method needs to be passed arguments in the form of Object and it's props",
     notSomeProps:

--- a/modules/node_modules/@colony/purser-ledger/class.js
+++ b/modules/node_modules/@colony/purser-ledger/class.js
@@ -31,7 +31,6 @@ export default class LedgerWallet extends GenericWallet {
              */
             userInputValidator({
               firstArgument: transactionObject,
-              requiredAll: REQUIRED_PROPS.SIGN_TRANSACTION,
             });
             const { chainId = this.chainId } = transactionObject || {};
             return signTransaction(

--- a/modules/node_modules/@colony/purser-ledger/staticMethods.js
+++ b/modules/node_modules/@colony/purser-ledger/staticMethods.js
@@ -73,87 +73,91 @@ export const signTransaction = async ({
      * parameter:
      * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
      */
-    const unsignedTransaction = await new EthereumTx({
-      /*
-       * We could really do with some BN.js flow types declarations :(
-       */
-      gasPrice: hexSequenceNormalizer(
+    const unsignedTransaction = await new EthereumTx(
+      Object.assign(
+        {},
+        {
+          /*
+           * We could really do with some BN.js flow types declarations :(
+           */
+          gasPrice: hexSequenceNormalizer(
+            /*
+             * @TODO Add `bigNumber` `toHexString` wrapper method
+             *
+             * Flow confuses bigNumber's `toString` with the String object
+             * prototype `toString` method
+             */
+            /* $FlowFixMe */
+            multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
+          ),
+          gasLimit: hexSequenceNormalizer(
+            /*
+             * @TODO Add `bigNumber` `toHexString` wrapper method
+             *
+             * Flow confuses bigNumber's `toString` with the String object
+             * prototype `toString` method
+             */
+            /* $FlowFixMe */
+            multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
+          ),
+          chainId,
+          /*
+           * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
+           * Eg: '3' to be '03', `12c` to be `012c`
+           */
+          nonce: hexSequenceNormalizer(
+            /*
+             * @TODO Add `bigNumber` `toHexString` wrapper method
+             *
+             * Flow confuses bigNumber's `toString` with the String object
+             * prototype `toString` method
+             */
+            /* $FlowFixMe */
+            multipleOfTwoHexValueNormalizer(nonce.toString(16)),
+          ),
+          // to: addressNormalizer(to),
+          value: hexSequenceNormalizer(
+            /*
+             * @TODO Add `bigNumber` `toHexString` wrapper method
+             *
+             * Flow confuses bigNumber's `toString` with the String object
+             * prototype `toString` method
+             */
+            /* $FlowFixMe */
+            multipleOfTwoHexValueNormalizer(value.toString(16)),
+          ),
+          data: hexSequenceNormalizer(inputData),
+          /*
+           * The transaction object needs to be seeded with the (R) and (S) signature components with
+           * empty data, and the Reco(V)ery param as the chain id (all, im hex string format).
+           *
+           * See this issue for context:
+           * https://github.com/LedgerHQ/ledgerjs/issues/43
+           */
+          r: hexSequenceNormalizer(
+            multipleOfTwoHexValueNormalizer(String(SIGNATURE.R)),
+          ),
+          s: hexSequenceNormalizer(
+            multipleOfTwoHexValueNormalizer(String(SIGNATURE.S)),
+          ),
+          v: hexSequenceNormalizer(
+            /*
+             * @TODO Add `bigNumber` `toHexString` wrapper method
+             *
+             * Flow confuses bigNumber's `toString` with the String object
+             * prototype `toString` method
+             */
+            /* $FlowFixMe */
+            multipleOfTwoHexValueNormalizer(chainId.toString(16)),
+          ),
+        },
         /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
+         * Only send (and normalize) the destingation address if one was
+         * provided in the initial transaction object.
          */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
+        typeof to !== 'undefined' ? { to: addressNormalizer(to) } : {},
       ),
-      gasLimit: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
-      ),
-      chainId,
-      /*
-       * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
-       * Eg: '3' to be '03', `12c` to be `012c`
-       */
-      nonce: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(nonce.toString(16)),
-      ),
-      /*
-       * Trezor service requires the prefix from the address to be stripped
-       */
-      to: addressNormalizer(to),
-      value: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(value.toString(16)),
-      ),
-      /*
-       * Trezor service requires the prefix from the input data to be stripped
-       */
-      data: hexSequenceNormalizer(inputData),
-      /*
-       * The transaction object needs to be seeded with the (R) and (S) signature components with
-       * empty data, and the Reco(V)ery param as the chain id (all, im hex string format).
-       *
-       * See this issue for context:
-       * https://github.com/LedgerHQ/ledgerjs/issues/43
-       */
-      r: hexSequenceNormalizer(
-        multipleOfTwoHexValueNormalizer(String(SIGNATURE.R)),
-      ),
-      s: hexSequenceNormalizer(
-        multipleOfTwoHexValueNormalizer(String(SIGNATURE.S)),
-      ),
-      v: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(chainId.toString(16)),
-      ),
-    });
+    );
     /*
      * Sign the transaction object via your Ledger Wallet
      *

--- a/modules/node_modules/@colony/purser-metamask/class.js
+++ b/modules/node_modules/@colony/purser-metamask/class.js
@@ -30,11 +30,7 @@ import { methodCaller, setStateEventObserver } from './helpers';
 import { validateMetamaskState } from './validators';
 import { signMessage as signMessageMethodLink } from './methodLinks';
 
-import {
-  PUBLICKEY_RECOVERY_MESSAGE,
-  STD_ERRORS,
-  REQUIRED_PROPS as REQUIRED_PROPS_METAMASK,
-} from './defaults';
+import { PUBLICKEY_RECOVERY_MESSAGE, STD_ERRORS } from './defaults';
 import {
   MetamaskWallet as messages,
   staticMethods as staticMethodsMessages,
@@ -98,12 +94,6 @@ export default class MetamaskWallet {
              */
             userInputValidator({
               firstArgument: transactionObject,
-              /*
-               * @NOTE We're using the locally defined Required prop
-               * As opposed to the one imported from core, like we do for the
-               * other two methods
-               */
-              requiredAll: REQUIRED_PROPS_METAMASK.SIGN_TRANSACTION,
             });
             return signTransaction(
               Object.assign({}, transactionObject, { from: this.address }),

--- a/modules/node_modules/@colony/purser-metamask/defaults.js
+++ b/modules/node_modules/@colony/purser-metamask/defaults.js
@@ -7,10 +7,3 @@ export const STD_ERRORS: Object = {
   CANCEL_MSG_SIGN: 'User denied message signature',
   CANCEL_TX_SIGN: 'User denied transaction signature',
 };
-
-/*
- * Prop names used to validate user input against
- */
-export const REQUIRED_PROPS: Object = {
-  SIGN_TRANSACTION: ['to', 'value'],
-};

--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -91,22 +91,29 @@ export const signTransaction = async ({
     () =>
       new Promise(resolve =>
         signTransactionMethodLink(
-          {
-            from: addressNormalizer(from),
-            to: addressNormalizer(to),
+          Object.assign(
+            {},
+            {
+              from: addressNormalizer(from),
+              /*
+              * We don't need to normalize these three values since Metamask accepts
+              * number values directly, so we don't need to convert them to hex
+              */
+              value: value.toString(),
+              gas: gasLimit.toString(),
+              gasPrice: gasPrice.toString(),
+              data: hexSequenceNormalizer(inputData),
+              /*
+               * Most likely this value is `undefined`, but that is good (see above)
+               */
+              nonce: manualNonce,
+            },
             /*
-            * We don't need to normalize these three values since Metamask accepts
-            * number values directly, so we don't need to convert them to hex
-            */
-            value: value.toString(),
-            gas: gasLimit.toString(),
-            gasPrice: gasPrice.toString(),
-            data: hexSequenceNormalizer(inputData),
-            /*
-             * Most likely this value is `undefined`, but that is good (see above)
+             * Only send (and normalize) the destingation address if one was
+             * provided in the initial transaction object.
              */
-            nonce: manualNonce,
-          },
+            typeof to !== 'undefined' ? { to: addressNormalizer(to) } : {},
+          ),
           /*
            * @TODO Move into own (non-anonymous) method
            * This way we could better test it

--- a/modules/node_modules/@colony/purser-software/class.js
+++ b/modules/node_modules/@colony/purser-software/class.js
@@ -142,7 +142,6 @@ export default class SoftwareWallet {
              */
             userInputValidator({
               firstArgument: transactionObject,
-              requiredAll: REQUIRED_PROPS.SIGN_TRANSACTION,
             });
             const { chainId: transactionChainId = this.chainId } =
               transactionObject || {};

--- a/modules/node_modules/@colony/purser-software/staticMethods.js
+++ b/modules/node_modules/@colony/purser-software/staticMethods.js
@@ -51,24 +51,33 @@ export const signTransaction = async ({
     inputData,
   } = transactionObjectValidator(transactionObject);
   try {
-    const signedTransaction: string = await callback({
-      /*
-       * Ethers needs it's own "proprietary" version of bignumber to work.
-       */
-      gasPrice: bigNumberify(gasPrice.toString()),
-      /*
-       * Ethers needs it's own "proprietary" version of bignumber to work.
-       */
-      gasLimit: bigNumberify(gasLimit.toString()),
-      chainId,
-      nonce,
-      to: addressNormalizer(to),
-      /*
-       * Ethers needs it's own "proprietary" version of bignumber to work.
-       */
-      value: bigNumberify(value.toString()),
-      data: hexSequenceNormalizer(inputData),
-    });
+    const signedTransaction: string = await callback(
+      Object.assign(
+        {},
+        {
+          /*
+           * Ethers needs it's own "proprietary" version of bignumber to work.
+           */
+          gasPrice: bigNumberify(gasPrice.toString()),
+          /*
+           * Ethers needs it's own "proprietary" version of bignumber to work.
+           */
+          gasLimit: bigNumberify(gasLimit.toString()),
+          chainId,
+          nonce,
+          /*
+           * Ethers needs it's own "proprietary" version of bignumber to work.
+           */
+          value: bigNumberify(value.toString()),
+          data: hexSequenceNormalizer(inputData),
+        },
+        /*
+         * Only send (and normalize) the destingation address if one was
+         * provided in the initial transaction object.
+         */
+        typeof to !== 'undefined' ? { to: addressNormalizer(to) } : {},
+      ),
+    );
     return hexSequenceNormalizer(signedTransaction);
   } catch (caughtError) {
     throw new Error(

--- a/modules/node_modules/@colony/purser-software/staticMethods.js
+++ b/modules/node_modules/@colony/purser-software/staticMethods.js
@@ -72,9 +72,15 @@ export const signTransaction = async ({
     return hexSequenceNormalizer(signedTransaction);
   } catch (caughtError) {
     throw new Error(
-      `${messages.cannotSign} ${objectToErrorString(
-        transactionObject,
-      )} Error: ${caughtError.message}`,
+      `${messages.cannotSign} ${objectToErrorString({
+        gasPrice,
+        gasLimit,
+        chainId,
+        nonce,
+        to,
+        value,
+        inputData,
+      })} Error: ${caughtError.message}`,
     );
   }
 };

--- a/modules/node_modules/@colony/purser-trezor/class.js
+++ b/modules/node_modules/@colony/purser-trezor/class.js
@@ -2,6 +2,7 @@
 
 import GenericWallet from '@colony/purser-core/genericWallet';
 import { userInputValidator } from '@colony/purser-core/helpers';
+import { warning } from '@colony/purser-core/utils';
 import { DESCRIPTORS, REQUIRED_PROPS } from '@colony/purser-core/defaults';
 import { TYPE_HARDWARE, SUBTYPE_TREZOR } from '@colony/purser-core/types';
 
@@ -11,6 +12,9 @@ import type {
 } from '@colony/purser-core/flowtypes';
 
 import { signTransaction, signMessage, verifyMessage } from './staticMethods';
+
+import { classInstance as messages } from './messages';
+import { REQUIRED_PROPS as REQUIRED_TREZOR_PROPS } from './defaults';
 
 const { WALLET_PROPS } = DESCRIPTORS;
 
@@ -27,14 +31,33 @@ export default class TrezorWallet extends GenericWallet {
         {},
         {
           value: async (transactionObject: TransactionObjectType) => {
+            let requiredSignProps: Array<String> =
+              REQUIRED_TREZOR_PROPS.SIGN_TRANSACTION;
+            const { chainId = this.chainId, to } = transactionObject || {};
+            /*
+             * If we don't have a destination address, it means the user wants
+             * to deploy a contract.
+             *
+             * For this the Trezor service requires a `inputData` value set.
+             *
+             * Otherwise, a `to` address *must* be set.
+             */
+            if (typeof to === 'undefined') {
+              requiredSignProps =
+                REQUIRED_TREZOR_PROPS.SIGN_TRANSACTION_CONTRACT;
+              /*
+               * Warn the user (in dev mode, at least) about Trezor's contract
+               * deployment requirements
+               */
+              warning(messages.signContractDeployment);
+            }
             /*
              * Validate the trasaction's object input
              */
             userInputValidator({
               firstArgument: transactionObject,
-              requiredAll: REQUIRED_PROPS.SIGN_TRANSACTION,
+              requiredAll: requiredSignProps,
             });
-            const { chainId = this.chainId } = transactionObject || {};
             return signTransaction(
               Object.assign({}, transactionObject, {
                 derivationPath: await this.derivationPath,

--- a/modules/node_modules/@colony/purser-trezor/defaults.js
+++ b/modules/node_modules/@colony/purser-trezor/defaults.js
@@ -51,3 +51,11 @@ export const STD_ERRORS: Object = {
   CANCEL_TX_SIGN: 'Action cancelled by user',
   INVALID_SIGN: 'Invalid signature',
 };
+
+/*
+ * Prop names used to validate user input against
+ */
+export const REQUIRED_PROPS: Object = {
+  SIGN_TRANSACTION: ['to'],
+  SIGN_TRANSACTION_CONTRACT: ['inputData'],
+};

--- a/modules/node_modules/@colony/purser-trezor/index.js
+++ b/modules/node_modules/@colony/purser-trezor/index.js
@@ -14,7 +14,7 @@ import type { WalletArgumentsType } from '@colony/purser-core/flowtypes';
 import TrezorWallet from './class';
 import { payloadListener } from './helpers';
 
-import { staticMethodsMessages as messages } from './messages';
+import { staticMethods as messages } from './messages';
 import { STD_ERRORS } from './defaults';
 import { PAYLOAD_XPUB } from './payloads';
 
@@ -101,6 +101,13 @@ export const open = async (
      * But throw otherwise, so we can see what's going on
      */
     throw new Error(
+      /*
+       * @TODO Move message to general
+       *
+       * Right now this message string is added under the "static methods" category.
+       * Since this is used in multiple places, there's a case to be made about
+       * making it a "general" category message.
+       */
       `${messages.userExportGenericError}: ${objectToErrorString(
         modifiedPayloadObject,
       )} ${caughtError.message}`,

--- a/modules/node_modules/@colony/purser-trezor/messages.js
+++ b/modules/node_modules/@colony/purser-trezor/messages.js
@@ -1,7 +1,12 @@
 /* @flow */
 /* eslint-disable max-len */
 
-export const staticMethodsMessages: Object = {
+export const classInstance: Object = {
+  signContractDeployment:
+    'In order to sign a contract deployment transaction (Not having a destination address), the Trezor service requires the `inputData` prop value to be set',
+};
+
+export const staticMethods: Object = {
   userExportCancel:
     'User cancelled the account export request (via Window prompt)',
   userExportGenericError:
@@ -14,9 +19,3 @@ export const staticMethodsMessages: Object = {
   messageSignatureOnlyTrezor:
     'Please take note: The message signature produced by a trezor wallet can only be verified using that trezor wallet (verifyMessage method)',
 };
-
-const trezorMessages = {
-  staticMethodsMessages,
-};
-
-export default trezorMessages;

--- a/modules/node_modules/@colony/purser-trezor/staticMethods.js
+++ b/modules/node_modules/@colony/purser-trezor/staticMethods.js
@@ -28,7 +28,7 @@ import { HEX_HASH_TYPE, SIGNATURE } from '@colony/purser-core/defaults';
 
 import { payloadListener } from './helpers';
 
-import { staticMethodsMessages as messages } from './messages';
+import { staticMethods as messages } from './messages';
 import { STD_ERRORS } from './defaults';
 import { PAYLOAD_SIGNTX, PAYLOAD_SIGNMSG, PAYLOAD_VERIFYMSG } from './payloads';
 
@@ -70,143 +70,153 @@ export const signTransaction = async ({
    * Between the unsigned EthereumTx signature object values and the values
    * sent to the Trezor server
    */
-  const unsignedTransaction = await new EthereumTx({
-    /*
-     * We could really do with some BN.js flow types declarations :(
-     */
-    gasPrice: hexSequenceNormalizer(
+  const unsignedTransaction = await new EthereumTx(
+    Object.assign(
+      {},
+      {
+        /*
+         * We could really do with some BN.js flow types declarations :(
+         */
+        gasPrice: hexSequenceNormalizer(
+          /*
+           * @TODO Add `bigNumber` `toHexString` wrapper method
+           *
+           * Flow confuses bigNumber's `toString` with the String object
+           * prototype `toString` method
+           */
+          /* $FlowFixMe */
+          multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
+        ),
+        gasLimit: hexSequenceNormalizer(
+          /*
+           * @TODO Add `bigNumber` `toHexString` wrapper method
+           *
+           * Flow confuses bigNumber's `toString` with the String object
+           * prototype `toString` method
+           */
+          /* $FlowFixMe */
+          multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
+        ),
+        chainId,
+        /*
+         * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
+         * Eg: '3' to be '03', `12c` to be `012c`
+         */
+        nonce: hexSequenceNormalizer(
+          /*
+           * @TODO Add `bigNumber` `toHexString` wrapper method
+           *
+           * Flow confuses bigNumber's `toString` with the String object
+           * prototype `toString` method
+           */
+          /* $FlowFixMe */
+          multipleOfTwoHexValueNormalizer(nonce.toString(16)),
+        ),
+        value: hexSequenceNormalizer(
+          /*
+           * @TODO Add `bigNumber` `toHexString` wrapper method
+           *
+           * Flow confuses bigNumber's `toString` with the String object
+           * prototype `toString` method
+           */
+          /* $FlowFixMe */
+          multipleOfTwoHexValueNormalizer(value.toString(16)),
+        ),
+        data: hexSequenceNormalizer(inputData),
+        /*
+         * The transaction object needs to be seeded with the (R) and (S) signature components with
+         * empty data, and the Reco(V)ery param as the chain id (all, im hex string format).
+         *
+         * See this issue for context:
+         * https://github.com/LedgerHQ/ledgerjs/issues/43
+         */
+        r: hexSequenceNormalizer(
+          multipleOfTwoHexValueNormalizer(String(SIGNATURE.R)),
+        ),
+        s: hexSequenceNormalizer(
+          multipleOfTwoHexValueNormalizer(String(SIGNATURE.S)),
+        ),
+        v: hexSequenceNormalizer(
+          /*
+           * @TODO Add `bigNumber` `toHexString` wrapper method
+           *
+           * Flow confuses bigNumber's `toString` with the String object
+           * prototype `toString` method
+           */
+          /* $FlowFixMe */
+          multipleOfTwoHexValueNormalizer(chainId.toString(16)),
+        ),
+      },
       /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
+       * Only set (and normalize) the destingation address if one was
+       * provided in the initial transaction object.
        */
-      /* $FlowFixMe */
-      multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
+      typeof to !== 'undefined' ? { to: addressNormalizer(to) } : {},
     ),
-    gasLimit: hexSequenceNormalizer(
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
-    ),
-    chainId,
-    /*
-     * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
-     * Eg: '3' to be '03', `12c` to be `012c`
-     */
-    nonce: hexSequenceNormalizer(
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      multipleOfTwoHexValueNormalizer(nonce.toString(16)),
-    ),
-    /*
-     * Trezor service requires the prefix from the address to be stripped
-     */
-    to: addressNormalizer(to),
-    value: hexSequenceNormalizer(
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      multipleOfTwoHexValueNormalizer(value.toString(16)),
-    ),
-    /*
-     * Trezor service requires the prefix from the input data to be stripped
-     */
-    data: hexSequenceNormalizer(inputData),
-    /*
-     * The transaction object needs to be seeded with the (R) and (S) signature components with
-     * empty data, and the Reco(V)ery param as the chain id (all, im hex string format).
-     *
-     * See this issue for context:
-     * https://github.com/LedgerHQ/ledgerjs/issues/43
-     */
-    r: hexSequenceNormalizer(
-      multipleOfTwoHexValueNormalizer(String(SIGNATURE.R)),
-    ),
-    s: hexSequenceNormalizer(
-      multipleOfTwoHexValueNormalizer(String(SIGNATURE.S)),
-    ),
-    v: hexSequenceNormalizer(
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      multipleOfTwoHexValueNormalizer(chainId.toString(16)),
-    ),
-  });
+  );
   /*
    * Modify the default payload to set the transaction details
    */
-  const modifiedPayloadObject: Object = Object.assign({}, PAYLOAD_SIGNTX, {
+  const modifiedPayloadObject: Object = Object.assign(
+    {},
+    PAYLOAD_SIGNTX,
+    {
+      /*
+       * Path needs to be sent in as an derivation path array
+       */
+      address_n: fromString(
+        derivationPathNormalizer(derivationPath),
+        true,
+      ).toPathArray(),
+      /*
+       * @TODO Add `bigNumber` `toHexString` wrapper method
+       *
+       * Flow confuses bigNumber's `toString` with the String object
+       * prototype `toString` method
+       */
+      /* $FlowFixMe */
+      gas_price: multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
+      /*
+       * @TODO Add `bigNumber` `toHexString` wrapper method
+       *
+       * Flow confuses bigNumber's `toString` with the String object
+       * prototype `toString` method
+       */
+      /* $FlowFixMe */
+      gas_limit: multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
+      chain_id: chainId,
+      /*
+       * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
+       * Eg: '3' to be '03', `12c` to be `012c`
+       *
+       * @TODO Add `bigNumber` `toHexString` wrapper method
+       *
+       * Flow confuses bigNumber's `toString` with the String object
+       * prototype `toString` method
+       */
+      /* $FlowFixMe */
+      nonce: multipleOfTwoHexValueNormalizer(nonce.toString(16)),
+      /*
+       * @TODO Add `bigNumber` `toHexString` wrapper method
+       *
+       * Flow confuses bigNumber's `toString` with the String object
+       * prototype `toString` method
+       */
+      /* $FlowFixMe */
+      value: multipleOfTwoHexValueNormalizer(value.toString(16)),
+      /*
+       * Trezor service requires the prefix from the input data to be stripped
+       */
+      data: hexSequenceNormalizer(inputData, false),
+    },
     /*
-     * Path needs to be sent in as an derivation path array
-     */
-    address_n: fromString(
-      derivationPathNormalizer(derivationPath),
-      true,
-    ).toPathArray(),
-    /*
-     * @TODO Add `bigNumber` `toHexString` wrapper method
+     * Only send (and normalize) the destingation address if one was
+     * provided in the initial transaction object.
      *
-     * Flow confuses bigNumber's `toString` with the String object
-     * prototype `toString` method
-     */
-    /* $FlowFixMe */
-    gas_price: multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
-    /*
-     * @TODO Add `bigNumber` `toHexString` wrapper method
-     *
-     * Flow confuses bigNumber's `toString` with the String object
-     * prototype `toString` method
-     */
-    /* $FlowFixMe */
-    gas_limit: multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
-    chain_id: chainId,
-    /*
-     * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
-     * Eg: '3' to be '03', `12c` to be `012c`
-     *
-     * @TODO Add `bigNumber` `toHexString` wrapper method
-     *
-     * Flow confuses bigNumber's `toString` with the String object
-     * prototype `toString` method
-     */
-    /* $FlowFixMe */
-    nonce: multipleOfTwoHexValueNormalizer(nonce.toString(16)),
-    /*
      * Trezor service requires the prefix from the address to be stripped
      */
-    to: addressNormalizer(to, false),
-    /*
-     * @TODO Add `bigNumber` `toHexString` wrapper method
-     *
-     * Flow confuses bigNumber's `toString` with the String object
-     * prototype `toString` method
-     */
-    /* $FlowFixMe */
-    value: multipleOfTwoHexValueNormalizer(value.toString(16)),
-    /*
-     * Trezor service requires the prefix from the input data to be stripped
-     */
-    data: hexSequenceNormalizer(inputData, false),
-  });
+    typeof to !== 'undefined' ? { to: addressNormalizer(to, false) } : {},
+  );
   /*
    * We need to catch the cancelled error since it's part of a normal user workflow
    */

--- a/modules/tests/purser-core/helpers/transactionObjectValidator.test.js
+++ b/modules/tests/purser-core/helpers/transactionObjectValidator.test.js
@@ -46,6 +46,13 @@ const mockedTransactionObject = {
 
 describe('`Core` Module', () => {
   describe('`transactionObjectValidator()` helper', () => {
+    afterEach(() => {
+      bigNumberValidator.mockClear();
+      safeIntegerValidator.mockClear();
+      addressValidator.mockClear();
+      hexSequenceValidator.mockClear();
+      bigNumber.mockClear();
+    });
     test("Validates all the transaction's object values", async () => {
       transactionObjectValidator(mockedTransactionObject);
       /*
@@ -119,6 +126,48 @@ describe('`Core` Module', () => {
         'inputData',
         TRANSACTION.INPUT_DATA,
       );
+    });
+    test('Validates destination (to), only if it was provided', async () => {
+      transactionObjectValidator({
+        derivationPath,
+        gasPrice,
+        gasLimit,
+        chainId,
+        nonce,
+        value,
+        inputData,
+      });
+      /*
+       * Validates gas price and gas limit
+       */
+      expect(bigNumberValidator).toHaveBeenCalled();
+      expect(bigNumberValidator).toHaveBeenCalledWith(gasPrice);
+      expect(bigNumberValidator).toHaveBeenCalledWith(gasLimit);
+      /*
+       * Validates the chain Id
+       */
+      expect(safeIntegerValidator).toHaveBeenCalled();
+      expect(safeIntegerValidator).toHaveBeenCalledWith(chainId);
+      /*
+       * Validates the nonce
+       */
+      expect(safeIntegerValidator).toHaveBeenCalled();
+      expect(safeIntegerValidator).toHaveBeenCalledWith(nonce);
+      /*
+       * Validates the transaction value
+       */
+      expect(bigNumberValidator).toHaveBeenCalled();
+      expect(bigNumberValidator).toHaveBeenCalledWith(value);
+      /*
+       * Validates the transaction input data
+       */
+      expect(hexSequenceValidator).toHaveBeenCalled();
+      expect(hexSequenceValidator).toHaveBeenCalledWith(inputData);
+      /*
+       * Doesn't validates the destination address, since it wasn't provided
+       */
+      expect(addressValidator).not.toHaveBeenCalled();
+      expect(addressValidator).not.toHaveBeenCalledWith(to);
     });
   });
 });

--- a/modules/tests/purser-ledger/class.test.js
+++ b/modules/tests/purser-ledger/class.test.js
@@ -61,6 +61,12 @@ const mockedSignatureObject = {
 
 describe('Ledger` Hardware Wallet Module', () => {
   describe('`LedgerWallet` class', () => {
+    afterEach(() => {
+      signTransaction.mockClear();
+      signMessage.mockClear();
+      verifyMessage.mockClear();
+      userInputValidator.mockClear();
+    });
     test('Creates a new wallet instance', () => {
       const ledgerWallet = new LedgerWalletClass(mockedInstanceArgument);
       expect(ledgerWallet).toBeInstanceOf(LedgerWalletClass);
@@ -145,7 +151,6 @@ describe('Ledger` Hardware Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedTransactionObject,
-        requiredAll: REQUIRED_PROPS.SIGN_TRANSACTION,
       });
     });
     test(

--- a/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
@@ -212,7 +212,7 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
        */
       expect(handleLedgerConnectionError).toHaveBeenCalled();
     });
-    test('Signs a transaction without a destionation address', async () => {
+    test('Signs a transaction without a destination address', async () => {
       expect(
         signTransaction({
           gasPrice,

--- a/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
@@ -69,6 +69,15 @@ const mockedArgumentsObject = {
 describe('`Ledger` Hardware Wallet Module Static Methods', () => {
   afterEach(() => {
     EthereumTx.mockClear();
+    derivationPathNormalizer.mockClear();
+    multipleOfTwoHexValueNormalizer.mockClear();
+    addressNormalizer.mockClear();
+    hexSequenceNormalizer.mockClear();
+    ledgerConnection.mockClear();
+    handleLedgerConnectionError.mockClear();
+    transactionObjectValidator.mockClear();
+    derivationPathValidator.mockClear();
+    utils.warning.mockClear();
   });
   describe('`signTransaction()` static method', () => {
     test('Calls the correct ledger app method', async () => {
@@ -202,6 +211,19 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
        * Handles the specific transport error
        */
       expect(handleLedgerConnectionError).toHaveBeenCalled();
+    });
+    test('Signs a transaction without a destionation address', async () => {
+      expect(
+        signTransaction({
+          gasPrice,
+          gasLimit,
+          chainId,
+          nonce,
+          value,
+          inputData,
+        }),
+      ).resolves.not.toThrow();
+      expect(addressNormalizer).not.toHaveBeenCalled();
     });
   });
 });

--- a/modules/tests/purser-metamask/class.test.js
+++ b/modules/tests/purser-metamask/class.test.js
@@ -31,7 +31,6 @@ import {
 import {
   PUBLICKEY_RECOVERY_MESSAGE,
   STD_ERRORS,
-  REQUIRED_PROPS as REQUIRED_PROPS_METAMASK,
 } from '@colony/purser-metamask/defaults';
 
 jest.dontMock('@colony/purser-metamask/class');
@@ -255,7 +254,6 @@ describe('Metamask` Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedTransactionObject,
-        requiredAll: REQUIRED_PROPS_METAMASK.SIGN_TRANSACTION,
       });
     });
     test('Calls the correct method to sign a message', async () => {

--- a/modules/tests/purser-metamask/class.test.js
+++ b/modules/tests/purser-metamask/class.test.js
@@ -256,6 +256,14 @@ describe('Metamask` Wallet Module', () => {
         firstArgument: mockedTransactionObject,
       });
     });
+    test('Sign a transaction without a destination address', async () => {
+      const metamaskWallet = new MetamaskWalletClass({ address });
+      expect(
+        metamaskWallet.sign({
+          value: 'mockedValue',
+        }),
+      ).resolves.not.toThrow();
+    });
     test('Calls the correct method to sign a message', async () => {
       const metamaskWallet = new MetamaskWalletClass({ address });
       await metamaskWallet.signMessage();

--- a/modules/tests/purser-software/class.test.js
+++ b/modules/tests/purser-software/class.test.js
@@ -262,7 +262,6 @@ describe('`Software` Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedTransactionObject,
-        requiredAll: REQUIRED_PROPS.SIGN_TRANSACTION,
       });
     });
     test('`signMessages()` calls the correct static method', async () => {

--- a/modules/tests/purser-software/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-software/staticMethods/signTransaction.test.js
@@ -127,5 +127,24 @@ describe('`Software` Wallet Module', () => {
     test('Throws if something goes wrong', async () => {
       expect(signTransaction()).rejects.toThrow();
     });
+    test("Can be called with no 'to' prop", async () => {
+      expect(
+        signTransaction({
+          gasPrice,
+          gasLimit,
+          chainId,
+          nonce,
+          value,
+          inputData,
+          callback: () => {},
+        }),
+      ).resolves.not.toThrow();
+      /*
+       * Since we don't have an address, don't add a destination prop and don't
+       * try to normalize it
+       */
+      expect(addressNormalizer).not.toHaveBeenCalled();
+      expect(addressNormalizer).not.toHaveBeenCalledWith(to);
+    });
   });
 });

--- a/modules/tests/purser-trezor/class.test.js
+++ b/modules/tests/purser-trezor/class.test.js
@@ -5,6 +5,7 @@ import {
   signMessage,
   verifyMessage,
 } from '@colony/purser-trezor/staticMethods';
+import { warning } from '@colony/purser-core/utils';
 
 import { REQUIRED_PROPS } from '@colony/purser-core/defaults';
 import { REQUIRED_PROPS as REQUIRED_TREZOR_PROPS } from '@colony/purser-trezor/defaults';
@@ -24,6 +25,9 @@ jest.mock('@colony/purser-core/helpers', () =>
 );
 jest.mock('@colony/purser-core/normalizers', () =>
   require('@mocks/purser-core/normalizers'),
+);
+jest.mock('@colony/purser-core/utils', () =>
+  require('@mocks/purser-core/utils'),
 );
 
 /*
@@ -63,6 +67,7 @@ describe('Trezor` Hardware Wallet Module', () => {
       signMessage.mockClear();
       verifyMessage.mockClear();
       userInputValidator.mockClear();
+      warning.mockClear();
     });
     test('Creates a new wallet instance', () => {
       const trezorWallet = new TrezorWalletClass(mockedInstanceArgument);
@@ -136,6 +141,10 @@ describe('Trezor` Hardware Wallet Module', () => {
           firstArgument: {},
           requiredAll: REQUIRED_TREZOR_PROPS.SIGN_TRANSACTION_CONTRACT,
         });
+        /*
+         * Notify the user about the Trezor requirements
+         */
+        expect(warning).toHaveBeenCalled();
       },
     );
     test(

--- a/modules/tests/purser-trezor/class.test.js
+++ b/modules/tests/purser-trezor/class.test.js
@@ -7,6 +7,7 @@ import {
 } from '@colony/purser-trezor/staticMethods';
 
 import { REQUIRED_PROPS } from '@colony/purser-core/defaults';
+import { REQUIRED_PROPS as REQUIRED_TREZOR_PROPS } from '@colony/purser-trezor/defaults';
 import { TYPE_HARDWARE, SUBTYPE_TREZOR } from '@colony/purser-core/types';
 
 jest.dontMock('@colony/purser-trezor/class');
@@ -106,7 +107,7 @@ describe('Trezor` Hardware Wallet Module', () => {
         });
       },
     );
-    test('Validate `sign` method user input', async () => {
+    test('Validate `sign` method user input for transactions', async () => {
       const trezorWallet = new TrezorWalletClass(mockedInstanceArgument);
       await trezorWallet.sign(mockedTransactionObject);
       /*
@@ -115,9 +116,28 @@ describe('Trezor` Hardware Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedTransactionObject,
-        requiredAll: REQUIRED_PROPS.SIGN_TRANSACTION,
+        requiredAll: REQUIRED_TREZOR_PROPS.SIGN_TRANSACTION,
       });
     });
+    test(
+      'Validate `sign` method user input for contract deployments',
+      async () => {
+        const trezorWallet = new TrezorWalletClass(mockedInstanceArgument);
+        /*
+         * If we don't have a destination address (to field), then assume we
+         * deploy a contract, so check for the `inputData` prop
+         */
+        await trezorWallet.sign({});
+        /*
+         * Validate the input
+         */
+        expect(userInputValidator).toHaveBeenCalled();
+        expect(userInputValidator).toHaveBeenCalledWith({
+          firstArgument: {},
+          requiredAll: REQUIRED_TREZOR_PROPS.SIGN_TRANSACTION_CONTRACT,
+        });
+      },
+    );
     test(
       "Calls the `signMessage()` static method from the instance's methods",
       async () => {

--- a/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
@@ -67,6 +67,13 @@ const mockedArgumentsObject = {
 describe('`Trezor` Hardware Wallet Module Static Methods', () => {
   afterEach(() => {
     EthereumTx.mockClear();
+    derivationPathNormalizer.mockClear();
+    multipleOfTwoHexValueNormalizer.mockClear();
+    addressNormalizer.mockClear();
+    hexSequenceNormalizer.mockClear();
+    utils.warning.mockClear();
+    payloadListener.mockClear();
+    derivationPathValidator.mockClear();
   });
   describe('`signTransaction()` static method', () => {
     test('Creates the initial, unsigned signature', async () => {
@@ -178,6 +185,19 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
        * User cancelled, so we don't throw
        */
       expect(utils.warning).toHaveBeenCalled();
+    });
+    test('Signs a transaction without a destination address', async () => {
+      expect(
+        signTransaction({
+          gasPrice,
+          gasLimit,
+          chainId,
+          nonce,
+          value,
+          inputData,
+        }),
+      ).resolves.not.toThrow();
+      expect(addressNormalizer).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This PR removes and refactors the requirements for signing a transaction object.

Previously the `sign()` transaction method would require at least a `to`, `nonce` and `value` field props to be set. _(The remaining values were `default`ed)_
This was a problem for cases where you would want to deploy a contract, and in such cases you don't provide a destination address (`to`).

Here, we're removing all requirements _(just the implicit one remains -- all values must be passed in the form of an `Object`)_ from the `sign` methods of all wallet modules _(with the exception of Trezor, see note)_

_**Note: Trezor doesn't allow signing a transaction without a destination address being set (`to` field), and as such it makes it virtually impossible to deploy a contract using the Trezor wallet**_

- [x] Refactor _purser-core_ helper `transactionObjectValidator` check if the address is valid only if one was provided
- [x] Refactor _purser-software_ to drop requirements when signing a transaction
- [x] Refactor _purser-ledger_ to drop requirements when signing a transaction
- [x] Refactor _purser-metamask_ to drop requirements when signing a transaction
- [x] Refactor _purser-trezor_ to drop requirements when signing a transaction

**Unit tests:**
- [x] Remove _purser-software_ requirements checks after refactor
- [x] Remove _purser-ledger_ requirements checks after refactor
- [x] Remove _purser-metamask_ requirements checks after refactor
- [x] Change _purser-trezor_ requirements checks after refactor
- [x] Add _purser-core_ helper `transactionObjectValidator` check for the destination address _(or lack there of)_

**Documentation:**
- [x] Add _Common Wallet Interface_ note about signing transaction, requirements and limitation when trying to deploy a contract