### PR TITLE
Fix ethers imports that changed in v4

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     '^@mocks/(.*)$': '<rootDir>/modules/tests/mocks/@colony/$1',
     '^ethers/wallet$': '<rootDir>/modules/tests/mocks/ethers/wallet/index.js',
     '^ethers/utils$': '<rootDir>/modules/tests/mocks/ethers/utils/index.js',
+    '^ethers/utils/secret-storage$': '<rootDir>/modules/tests/mocks/ethers/utils/secret-storage.js',
     '^@ledgerhq/hw-transport-u2f$': '<rootDir>/modules/tests/mocks/ledger-hw-transport-u2f.js',
     '^@ledgerhq/hw-app-eth$': '<rootDir>/modules/tests/mocks/ledger-hw-app-eth.js',
     '^ethereumjs-tx$': '<rootDir>/modules/tests/mocks/ethereumjs-tx.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,8 @@ module.exports = {
     '^ethers/wallet$': '<rootDir>/modules/tests/mocks/ethers/wallet/index.js',
     '^ethers/utils$': '<rootDir>/modules/tests/mocks/ethers/utils/index.js',
     '^ethers/utils/secret-storage$': '<rootDir>/modules/tests/mocks/ethers/utils/secret-storage.js',
+    '^ethers/utils/hdnode$': '<rootDir>/modules/tests/mocks/ethers/utils/hdnode.js',
+    '^ethers/utils/json-wallet': '<rootDir>/modules/tests/mocks/ethers/utils/json-wallet.js',
     '^@ledgerhq/hw-transport-u2f$': '<rootDir>/modules/tests/mocks/ledger-hw-transport-u2f.js',
     '^@ledgerhq/hw-app-eth$': '<rootDir>/modules/tests/mocks/ledger-hw-app-eth.js',
     '^ethereumjs-tx$': '<rootDir>/modules/tests/mocks/ethereumjs-tx.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,6 @@ module.exports = {
     '^@mocks/(.*)$': '<rootDir>/modules/tests/mocks/@colony/$1',
     '^ethers/wallet$': '<rootDir>/modules/tests/mocks/ethers/wallet/index.js',
     '^ethers/utils$': '<rootDir>/modules/tests/mocks/ethers/utils/index.js',
-    '^ethers/utils/secret-storage$': '<rootDir>/modules/tests/mocks/ethers/utils/secret-storage.js',
     '^@ledgerhq/hw-transport-u2f$': '<rootDir>/modules/tests/mocks/ledger-hw-transport-u2f.js',
     '^@ledgerhq/hw-app-eth$': '<rootDir>/modules/tests/mocks/ledger-hw-app-eth.js',
     '^ethereumjs-tx$': '<rootDir>/modules/tests/mocks/ethereumjs-tx.js',

--- a/modules/node_modules/@colony/purser-core/flowtypes.js
+++ b/modules/node_modules/@colony/purser-core/flowtypes.js
@@ -50,6 +50,7 @@ export type WalletArgumentsType = {
   addressCount?: number,
   privateKey?: string,
   mnemonic?: string,
+  originalMnemonic?: string,
   path?: string,
   keystore?: string,
   entropy?: Uint8Array,

--- a/modules/node_modules/@colony/purser-core/genericWallet.js
+++ b/modules/node_modules/@colony/purser-core/genericWallet.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { SigningKey } from 'ethers/wallet';
+import { SigningKey } from 'ethers/utils';
 import HDKey from 'hdkey';
 
 import {

--- a/modules/node_modules/@colony/purser-core/genericWallet.js
+++ b/modules/node_modules/@colony/purser-core/genericWallet.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { SigningKey } from 'ethers/utils';
+import { computeAddress } from 'ethers/utils';
 import HDKey from 'hdkey';
 
 import {
@@ -122,7 +122,7 @@ export default class GenericWallet {
         /*
          * Generate the address from the derived public key
          */
-        const addressFromPublicKey = SigningKey.publicKeyToAddress(
+        const addressFromPublicKey = computeAddress(
           /*
            * Sadly Flow doesn't have the correct types for node's Buffer Object
            */

--- a/modules/node_modules/@colony/purser-software/class.js
+++ b/modules/node_modules/@colony/purser-software/class.js
@@ -177,11 +177,13 @@ export default class SoftwareWallet {
             return signMessage({
               message: messageObject.message,
               /*
-               * Private key needs to be bound since this method doesn't
-               * expect to be destructured from the instance object, and
-               * uses `this` to get the value of the private key
+               * @NOTE We need to bind the whole ethers instance
+               *
+               * Since the `signMessage` will look for different methods inside the
+               * class's prototype, and if it fails to find them, it will
+               * crash
                */
-              callback: (ethersSignMessage: any).bind({ privateKey }),
+              callback: (ethersSignMessage: any).bind(ethersInstance),
             });
           },
         },

--- a/modules/node_modules/@colony/purser-software/class.js
+++ b/modules/node_modules/@colony/purser-software/class.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import secretStorage from 'ethers/utils/secret-storage';
+import { encrypt } from 'ethers/utils/secret-storage';
 import { privateToPublic } from 'ethereumjs-util';
 
 import {
@@ -57,7 +57,7 @@ export default class SoftwareWallet {
 
   publicKey: string;
 
-  mnemonic: string;
+  originalMnemonic: string;
 
   derivationPath: string;
 
@@ -83,16 +83,17 @@ export default class SoftwareWallet {
 
   verifyMessage: (...*) => Promise<string>;
 
-  constructor({
-    address,
-    privateKey,
-    password,
-    mnemonic,
-    keystore,
-    chainId,
-    sign: ethersSign,
-    signMessage: ethersSignMessage,
-  }: WalletArgumentsType = {}) {
+  constructor(ethersInstance: WalletArgumentsType = {}) {
+    const {
+      address,
+      privateKey,
+      password,
+      originalMnemonic: mnemonic,
+      keystore,
+      chainId,
+      sign: ethersSign,
+      signMessage: ethersSignMessage,
+    } = ethersInstance;
     /*
      * Validate the private key and address that's coming in from ethers.
      */
@@ -147,8 +148,15 @@ export default class SoftwareWallet {
               transactionObject || {};
             return signTransaction(
               Object.assign({}, transactionObject, {
-                callback: ethersSign,
                 chainId: transactionChainId,
+                /*
+                 * @NOTE We need to bind the whole ethers instance
+                 *
+                 * Since the `sign` will look for different methods inside the
+                 * class's prototype, and if it fails to find them, it will
+                 * crash
+                 */
+                callback: (ethersSign: any).bind(ethersInstance),
               }),
             );
           },
@@ -244,7 +252,7 @@ export default class SoftwareWallet {
                * The password won't work if it's not a string, so it will be best if
                * we write a string validator for it
                */
-              secretStorage.encrypt(
+              encrypt(
                 privateKey,
                 internalEncryptionPassword.toString(),
               ),
@@ -261,7 +269,7 @@ export default class SoftwareWallet {
            * The password won't work if it's not a string, so it will be best if
            * we write a string validator for it
            */
-          secretStorage.encrypt(
+          encrypt(
             privateKey,
             internalEncryptionPassword.toString(),
           )

--- a/modules/node_modules/@colony/purser-software/index.js
+++ b/modules/node_modules/@colony/purser-software/index.js
@@ -2,6 +2,7 @@
 
 import { Wallet as EthersWallet } from 'ethers/wallet';
 import { isValidMnemonic, fromMnemonic } from 'ethers/utils/hdnode';
+import { isSecretStorageWallet } from 'ethers/utils/json-wallet';
 
 import {
   derivationPathSerializer,
@@ -82,7 +83,7 @@ export const open = async (
     /*
      * @TODO Detect if existing but not valid keystore, and warn the user
      */
-    if (keystore && EthersWallet.isEncryptedWallet(keystore) && password) {
+    if (keystore && isSecretStorageWallet(keystore) && password) {
       const keystoreWallet: Object =
         /*
          * Prettier suggests changes that would always result in eslint
@@ -90,7 +91,7 @@ export const open = async (
          *
          * Nevertheless, by inserting this comment, it works :)
          */
-        await EthersWallet.fromEncryptedWallet(keystore, password);
+        await EthersWallet.fromEncryptedJson(keystore, password);
       /*
        * Set the keystore and password props on the instance object.
        *

--- a/modules/node_modules/@colony/purser-software/index.js
+++ b/modules/node_modules/@colony/purser-software/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import { HDNode, Wallet as EthersWallet } from 'ethers/wallet';
+import { Wallet as EthersWallet } from 'ethers/wallet';
+import { isValidMnemonic, fromMnemonic } from 'ethers/utils/hdnode';
 
 import {
   derivationPathSerializer,
@@ -110,8 +111,8 @@ export const open = async (
     /*
      * @TODO Detect if existing but not valid mnemonic, and warn the user
      */
-    if (mnemonic && HDNode.isValidMnemonic(mnemonic)) {
-      const mnemonicWallet: Object = HDNode.fromMnemonic(mnemonic).derivePath(
+    if (mnemonic && isValidMnemonic(mnemonic)) {
+      const mnemonicWallet: Object = fromMnemonic(mnemonic).derivePath(
         derivationPath,
       );
       extractedPrivateKey = mnemonicWallet.privateKey;
@@ -134,9 +135,13 @@ export const open = async (
      * This needs to be refactored to pass values to the SoftwareWallet
      * class in a less repetitious way
      */
-    privateKeyWallet.mnemonic = mnemonic;
     privateKeyWallet.password = password;
     privateKeyWallet.chainId = chainId;
+    /*
+     * @NOTE mnemonic prop was renamed due to naming conflict with getter-only
+     * ethers prop
+     */
+    privateKeyWallet.originalMnemonic = mnemonic;
     return new SoftwareWallet(privateKeyWallet);
   } catch (caughtError) {
     throw new Error(

--- a/modules/node_modules/@colony/purser-software/staticMethods.js
+++ b/modules/node_modules/@colony/purser-software/staticMethods.js
@@ -1,7 +1,9 @@
 /* @flow */
 
-import { bigNumberify } from 'ethers/utils';
-import { Wallet as EthersWallet } from 'ethers/wallet';
+import {
+  bigNumberify,
+  verifyMessage as verifyEthersMessage,
+} from 'ethers/utils';
 
 import {
   transactionObjectValidator,
@@ -154,7 +156,7 @@ export const verifyMessage = async ({
     signatureMessage,
   );
   try {
-    const recoveredAddress: string = EthersWallet.verifyMessage(
+    const recoveredAddress: string = verifyEthersMessage(
       message,
       signature,
     );

--- a/modules/node_modules/@colony/purser-software/staticMethods.js
+++ b/modules/node_modules/@colony/purser-software/staticMethods.js
@@ -114,7 +114,7 @@ export const signMessage = async ({ message, callback }: Object = {}): Promise<
    */
   messageValidator(message);
   try {
-    const messageSignature: string = callback(message);
+    const messageSignature: string = await callback(message);
     /*
      * Normalize the message signature
      */

--- a/modules/tests/mocks/ethers/utils/hdnode.js
+++ b/modules/tests/mocks/ethers/utils/hdnode.js
@@ -1,0 +1,15 @@
+export const fromMnemonic = jest.fn(mnemonic => ({
+  derivePath: jest.fn(() => {
+    if (mnemonic === 'mocked-mnemonic') {
+      return { privateKey: 'mocked-private-key' };
+    }
+    return { privateKey: 'another-mocked-private-key' };
+  }),
+}));
+
+export const isValidMnemonic = jest.fn(mnemonic => {
+  if (mnemonic === 'mocked-mnemonic') {
+    return true;
+  }
+  return false;
+});

--- a/modules/tests/mocks/ethers/utils/index.js
+++ b/modules/tests/mocks/ethers/utils/index.js
@@ -1,7 +1,10 @@
 export const bigNumberify = jest.fn(value => value);
 
+export const computeAddress = jest.fn(buffer => buffer.toString());
+
 const ethersUtils = {
   bigNumberify,
+  computeAddress,
 };
 
 export default ethersUtils;

--- a/modules/tests/mocks/ethers/utils/index.js
+++ b/modules/tests/mocks/ethers/utils/index.js
@@ -2,6 +2,13 @@ export const bigNumberify = jest.fn(value => value);
 
 export const computeAddress = jest.fn(buffer => buffer.toString());
 
+export const verifyMessage = jest.fn((message, signature) => {
+  if (!message || !signature) {
+    throw new Error();
+  }
+  return 'mocked-recovered-address';
+});
+
 const ethersUtils = {
   bigNumberify,
   computeAddress,

--- a/modules/tests/mocks/ethers/utils/json-wallet.js
+++ b/modules/tests/mocks/ethers/utils/json-wallet.js
@@ -1,0 +1,7 @@
+export const isSecretStorageWallet = jest.fn(() => true);
+
+const jsonWallet = {
+  isSecretStorageWallet,
+};
+
+export default jsonWallet;

--- a/modules/tests/mocks/ethers/utils/secret-storage.js
+++ b/modules/tests/mocks/ethers/utils/secret-storage.js
@@ -1,5 +1,7 @@
+export const encrypt = jest.fn(() => 'mocked-keystore');
+
 const secretStorage = {
-  encrypt: jest.fn(() => 'mocked-keystore'),
+  encrypt,
 };
 
 export default secretStorage;

--- a/modules/tests/mocks/ethers/wallet/index.js
+++ b/modules/tests/mocks/ethers/wallet/index.js
@@ -41,14 +41,9 @@ export const HDNode = {
   }),
 };
 
-export const SigningKey = {
-  publicKeyToAddress: jest.fn(buffer => buffer.toString()),
-};
-
 const ethersWallet = {
   Wallet,
   HDNode,
-  SigningKey,
 };
 
 export default ethersWallet;

--- a/modules/tests/mocks/ethers/wallet/index.js
+++ b/modules/tests/mocks/ethers/wallet/index.js
@@ -17,13 +17,6 @@ Wallet.fromEncryptedWallet = jest.fn(() => ({
   mnemonic: 'mocked-mnemonic',
 }));
 
-Wallet.verifyMessage = jest.fn((message, signature) => {
-  if (!message || !signature) {
-    throw new Error();
-  }
-  return 'mocked-recovered-address';
-});
-
 export const HDNode = {
   fromMnemonic: jest.fn(mnemonic => ({
     derivePath: jest.fn(() => {

--- a/modules/tests/mocks/ethers/wallet/index.js
+++ b/modules/tests/mocks/ethers/wallet/index.js
@@ -9,34 +9,10 @@ export const Wallet = jest.fn().mockImplementation(privateKey => {
 
 Wallet.createRandom = jest.fn(() => ({ privateKey: 'mocked-private-key' }));
 
-Wallet.isEncryptedWallet = jest.fn(() => true);
-
-Wallet.fromEncryptedWallet = jest.fn(() => ({
+Wallet.fromEncryptedJson = jest.fn(() => ({
   privateKey: 'mocked-private-key',
   address: 'mocked-address',
   mnemonic: 'mocked-mnemonic',
 }));
 
-export const HDNode = {
-  fromMnemonic: jest.fn(mnemonic => ({
-    derivePath: jest.fn(() => {
-      if (mnemonic === 'mocked-mnemonic') {
-        return { privateKey: 'mocked-private-key' };
-      }
-      return { privateKey: 'another-mocked-private-key' };
-    }),
-  })),
-  isValidMnemonic: jest.fn(mnemonic => {
-    if (mnemonic === 'mocked-mnemonic') {
-      return true;
-    }
-    return false;
-  }),
-};
-
-const ethersWallet = {
-  Wallet,
-  HDNode,
-};
-
-export default ethersWallet;
+export default Wallet;

--- a/modules/tests/purser-core/genericWallet.test.js
+++ b/modules/tests/purser-core/genericWallet.test.js
@@ -1,5 +1,5 @@
 import HDKey from 'hdkey';
-import { SigningKey } from 'ethers/wallet';
+import { computeAddress } from 'ethers/utils';
 
 import GenericWallet from '@colony/purser-core/genericWallet';
 import {
@@ -16,7 +16,7 @@ import { NETWORK_IDS } from '@colony/purser-core/defaults';
 jest.dontMock('@colony/purser-core/genericWallet');
 
 jest.mock('hdkey');
-jest.mock('ethers/wallet');
+jest.mock('ethers/utils');
 jest.mock('@colony/purser-core/validators');
 /*
  * @TODO Fix manual mocks
@@ -49,6 +49,7 @@ describe('`Core` Module', () => {
   afterEach(() => {
     addressNormalizer.mockClear();
     hexSequenceNormalizer.mockClear();
+    computeAddress.mockClear();
   });
   describe('`GenericWallet` class', () => {
     test('Creates a new wallet instance', () => {
@@ -87,7 +88,7 @@ describe('`Core` Module', () => {
     test('Generates the address(es) from the public key(s)', () => {
       /* eslint-disable-next-line no-new */
       new GenericWallet(mockedArguments);
-      expect(SigningKey.publicKeyToAddress).toHaveBeenCalled();
+      expect(computeAddress).toHaveBeenCalled();
     });
     test('The Wallet Object has the required (correct) props', async () => {
       const genericWallet = new GenericWallet(mockedArguments);

--- a/modules/tests/purser-software/staticMethods/verifyMessage.test.js
+++ b/modules/tests/purser-software/staticMethods/verifyMessage.test.js
@@ -1,4 +1,4 @@
-import { Wallet as EthersWallet } from 'ethers/wallet';
+import { verifyMessage as verifyEthersMessage } from 'ethers/utils';
 
 import { messageVerificationObjectValidator } from '@colony/purser-core/helpers';
 import { addressValidator } from '@colony/purser-core/validators';
@@ -7,7 +7,7 @@ import { verifyMessage } from '@colony/purser-software/staticMethods';
 
 jest.dontMock('@colony/purser-software/staticMethods');
 
-jest.mock('ethers/wallet');
+jest.mock('ethers/utils');
 jest.mock('@colony/purser-core/validators');
 /*
  * @TODO Fix manual mocks
@@ -37,16 +37,13 @@ describe('`Software` Wallet Module', () => {
   afterEach(() => {
     messageVerificationObjectValidator.mockClear();
     addressValidator.mockClear();
-    EthersWallet.verifyMessage.mockClear();
+    verifyEthersMessage.mockClear();
   });
   describe('`verifyMessage()` static method', () => {
     test('Calls the correct EthersWallet static method', async () => {
       await verifyMessage(mockedArgumentsObject);
-      expect(EthersWallet.verifyMessage).toHaveBeenCalled();
-      expect(EthersWallet.verifyMessage).toHaveBeenCalledWith(
-        message,
-        signature,
-      );
+      expect(verifyEthersMessage).toHaveBeenCalled();
+      expect(verifyEthersMessage).toHaveBeenCalledWith(message, signature);
     });
     test("Validates the signature object's values", async () => {
       await verifyMessage(mockedArgumentsObject);

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,6 +586,52 @@
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@colony/eslint-config-colony/-/eslint-config-colony-6.0.0.tgz#85b26e9b92bc48679095fe4ac351bc8c2eeffa82"
 
+"@colony/purser-core@1.1.0", "@colony/purser-core@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-core/-/purser-core-1.1.0.tgz#782021ad409dc6ff164f8e86c67c68b3e5c55cad"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    bn.js "^4.11.8"
+    ethereumjs-util "^5.2.0"
+    ethers "^4.0.0"
+    hdkey "^1.1.0"
+
+"@colony/purser-ledger@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-ledger/-/purser-ledger-1.1.0.tgz#fd6f4848afaa3a1102ee8ab21f5ecdf308d34923"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@colony/purser-core" "1.1.0"
+    "@ledgerhq/hw-app-eth" "^4.19.0"
+    "@ledgerhq/hw-transport-u2f" "^4.20.0"
+    ethereumjs-tx "^1.3.6"
+
+"@colony/purser-metamask@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-metamask/-/purser-metamask-1.1.0.tgz#cd7e8658f3317c11c6f3b2872285fe8ffea281bb"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@colony/purser-core" "1.1.0"
+    lodash.isequal "^4.5.0"
+
+"@colony/purser-software@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-software/-/purser-software-1.1.0.tgz#16666ffe564d5ffd0d927e0dd236bca21747f9d2"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@colony/purser-core" "1.1.0"
+    ethereumjs-util "^5.2.0"
+    ethers "^4.0.0"
+
+"@colony/purser-trezor@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-trezor/-/purser-trezor-1.1.0.tgz#7960e35f926706ef593bd6aefe503e28f8d4b265"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@colony/purser-core" "1.1.0"
+    bip32-path "^0.4.2"
+    ethereumjs-tx "^1.3.6"
+
 "@kironeducation/flow-junit-transformer@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@kironeducation/flow-junit-transformer/-/flow-junit-transformer-0.3.0.tgz#ea1e57b01d7096012254a3d3dafc8afc7d97b8fe"


### PR DESCRIPTION
The recent `ethers` update to version `4` and the subsequent minor and patch versions changed a the import structure quite a bit, to the extent that `purser-software` failed to do it's most basic functions.

This PR changes most of the `import` structure and some of the method calls, to align with the new version.

Fixes:
- [x] `purser-software` `sign()` transaction static method
- [x] `purser-software` `signMessage()` static method
- [x] `purser-software` `verifyMessage()` static method
- [x] `purser-software` open a wallet using a `keystore`
- [x] `purser-core` `genericWallet` class _(use for the hardware wallets instances)_ recover address(es) from a public key

Unit tests:
- [x] re-do mocks to reflect the new import scheme
