### PR TITLE
Fix `purser-software` mnemonic when creating a new instance

### DIFF
--- a/modules/node_modules/@colony/purser-ledger/README.md
+++ b/modules/node_modules/@colony/purser-ledger/README.md
@@ -2,7 +2,7 @@
 
 A `javascript` library to interact with a [Ledger](https://www.ledger.com/) based Ethereum wallet.
 
-It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/api-wallet-object/).
+It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/interface-common-wallet-interface/).
 
 ### Installation
 ```js

--- a/modules/node_modules/@colony/purser-metamask/README.md
+++ b/modules/node_modules/@colony/purser-metamask/README.md
@@ -2,7 +2,7 @@
 
 A `javascript` library to interact with the a [Metamask](https://metamask.io/) based Ethereum wallet.
 
-It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/api-wallet-object/).
+It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/interface-common-wallet-interface/).
 
 ### Installation
 ```js

--- a/modules/node_modules/@colony/purser-software/README.md
+++ b/modules/node_modules/@colony/purser-software/README.md
@@ -2,7 +2,7 @@
 
 A `javascript` library to interact with a software Ethereum wallet, based on the [ethers.js](https://github.com/ethers-io/ethers.js/) library.
 
-It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/api-wallet-object/).
+It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/interface-common-wallet-interface/).
 
 ### Installation
 ```js

--- a/modules/node_modules/@colony/purser-software/index.js
+++ b/modules/node_modules/@colony/purser-software/index.js
@@ -210,6 +210,11 @@ export const create = async (
      */
     basicWallet.password = password;
     basicWallet.chainId = chainId;
+    /*
+     * @NOTE mnemonic prop was renamed due to naming conflict with getter-only
+     * ethers prop
+     */
+    basicWallet.originalMnemonic = basicWallet.mnemonic;
     return new SoftwareWallet(basicWallet);
   } catch (caughtError) {
     throw new Error(`${messages.create} Error: ${caughtError.message}`);

--- a/modules/node_modules/@colony/purser-trezor/README.md
+++ b/modules/node_modules/@colony/purser-trezor/README.md
@@ -2,7 +2,7 @@
 
 A `javascript` library to interact with a [Trezor](https://trezor.io/) based Ethereum wallet.
 
-It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/api-wallet-object/).
+It extracts all the complexity from setting up, maintaining and interacting with it, while providing you with a [predictable interface](https://docs.colony.io/purser/interface-common-wallet-interface/).
 
 ### Installation
 ```js


### PR DESCRIPTION
This PR is a hotfix to align the `create()` static method of `purser-software` to the new `mnemonic` naming scheme.

The `mnemonic` internal prop was renamed in [release v1.1.1](https://github.com/JoinColony/purser/releases/tag/v1.1.1) due to naming conflicts with the prop with the same name coming from `ethers`, but which was enforced in the new version as a getter only, so it became that we could not modify it anymore.

Also, this PR fixes the link to the _Common Wallet Interface_ documentation for all modules.