### PR TITLE
Fix `purser-metamask` to check if Metamask is on a pre-release version

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/helpers.js
+++ b/modules/node_modules/@colony/purser-metamask/helpers.js
@@ -23,12 +23,33 @@ export const detect = async (): Promise<boolean> => {
    * Modern Metamask Version
    */
   if (global.ethereum) {
-    if (!(await global.ethereum.isUnlocked())) {
+    /*
+     * @NOTE This is a temporary failsafe check, since Metmask is running an
+     * intermediate version which, while it contains most of the `ethereum`
+     * global object, it doesn't contain this helper method
+     *
+     * @TODO Remove legacy metmask object availability check
+     * After an adequate amount of time has passed
+     */
+    if (global.ethereum.isUnlocked && !(await global.ethereum.isUnlocked())) {
       throw new Error(messages.isLocked);
     }
-    if (!(await global.ethereum.isEnabled())) {
+    /*
+     * @NOTE This is a temporary failsafe check, since Metmask is running an
+     * intermediate version which, while it contains most of the `ethereum`
+     * global object, it doesn't contain this helper method
+     *
+     * @TODO Remove legacy metmask object availability check
+     * After an adequate amount of time has passed
+     */
+    if (global.ethereum.isEnabled && !(await global.ethereum.isEnabled())) {
       throw new Error(messages.notEnabled);
     }
+    /*
+     * @NOTE If the `isUnlocked` and the `isEnabled` methods are not available
+     * it means we are running the pre-release version of Metamask, just prior
+     * to the EIP-1102 update, so we just ignore those checks
+     */
     return true;
   }
   /*


### PR DESCRIPTION
This PR adds a simple check to `purser-metamask`'s `detect()` helper method to check if we're on the pre-release version of the EIP-1102 Metamask update.

We can tell this by checking the availability of the `window.ethereum.isUnlocked()` and `window.ethereum.isEnabled()` status checking methods.

If they're not available it means we're still in the days leading up to the [Nov. 2nd release.](https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8)