### PR TITLE
Fix purser-metamask .sign() to return signed transaction hex

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/flowtypes.js
+++ b/modules/node_modules/@colony/purser-metamask/flowtypes.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import type BigNumber from 'bn.js';
+
 export type MetamaskInpageProviderType = {
   enable: () => Promise<Array<string>>,
   mux: Object,
@@ -12,11 +14,32 @@ export type MetamaskInpageProviderType = {
 
 export type Web3CallbackType = (error: Error, result: string) => any;
 
+export type Web3TransactionType = {
+  blockHash: string,
+  blockNumber: number,
+  from: string,
+  gas: number,
+  gasPrice: BigNumber,
+  hash: string,
+  input: string,
+  nonce: number,
+  r: string,
+  s: string,
+  to: string,
+  transactionIndex: number,
+  v: string,
+  value: string,
+};
+
 export type MetamaskStateEventsObserverType = (state: Object) => any;
 
 export type MetamaskWalletConstructorArgumentsType = {
   address: string,
 };
+
+export type getTransactionMethodType = (
+  transactionHash: string,
+) => Promise<Web3TransactionType>;
 
 export type signMessageMethodType = (
   signature: string,

--- a/modules/node_modules/@colony/purser-metamask/methodLinks.js
+++ b/modules/node_modules/@colony/purser-metamask/methodLinks.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type {
+  getTransactionMethodType,
   signMessageMethodType,
   signTrasactionMethodType,
   verifyMessageMethodType,
@@ -12,6 +13,12 @@ import type {
  *
  * This assumes you do detection before trying to call them.
  */
+
+/**
+ * @method getTransaction
+ */
+export const getTransaction: getTransactionMethodType = (...args) =>
+  global.web3.eth.getTransaction(...args);
 
 /**
  * Sign a message. Is a wrapper for web3.personal.sign

--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -1,5 +1,8 @@
 /* @flow */
 
+import EthereumTx from 'ethereumjs-tx';
+import BigNumber from 'bn.js';
+
 import { warning } from '@colony/purser-core/utils';
 import {
   hexSequenceValidator,
@@ -20,6 +23,7 @@ import { HEX_HASH_TYPE } from '@colony/purser-core/defaults';
 
 import { methodCaller } from './helpers';
 import {
+  getTransaction as getTransactionMethodLink,
   signTransaction as signTransactionMethodLink,
   signMessage as signMessageMethodLink,
   verifyMessage as verifyMessageMethodLink,
@@ -118,7 +122,7 @@ export const signTransaction = async ({
            * @TODO Move into own (non-anonymous) method
            * This way we could better test it
            */
-          (error: Error, transactionHash: string) => {
+          async (error: Error, transactionHash: string) => {
             try {
               /*
                * Validate that the signature hash is in the correct format
@@ -130,7 +134,42 @@ export const signTransaction = async ({
               const normalizedTransactionHash: string = hexSequenceNormalizer(
                 transactionHash,
               );
-              return resolve(normalizedTransactionHash);
+              /*
+               * Get signed transaction object with transaction hash using Web3
+               * Include signature + any values MetaMask may have changed.
+               */
+              const {
+                gas,
+                gasPrice: signedGasPrice,
+                input: signedData,
+                nonce,
+                r,
+                s,
+                to: signedTo,
+                v,
+                value: signedValue
+              } = await getTransactionMethodLink(normalizedTransactionHash);
+              /*
+               * RLP encode (to hex string) with ethereumjs-tx, prefix with
+               * `0x` and return. Convert to BN all the numbers-as-strings.
+               */
+              const signedTransaction = new EthereumTx({
+                data: signedData,
+                gasLimit: new BigNumber(gas),
+                gasPrice: new BigNumber(signedGasPrice),
+                nonce: new BigNumber(nonce),
+                r,
+                s,
+                to: signedTo,
+                v,
+                value: new BigNumber(signedValue),
+              });
+              const serializedSignedTransaction =
+                signedTransaction.serialize().toString(HEX_HASH_TYPE);
+              const normalizedSignedTransaction = hexSequenceNormalizer(
+                serializedSignedTransaction,
+              )
+              return resolve(normalizedSignedTransaction);
             } catch (caughtError) {
               /*
                * Don't throw an Error if the user just cancels signing transaction.


### PR DESCRIPTION
Previously the transaction hash was being returned, which is different to how other wallet types behave. This caused code which expected the signed transaction hex string to be returned to break when used with the `purser-metamask` wallet.