### PR TITLE
Remove length check from hexSequenceValidator

### DIFF
--- a/modules/node_modules/@colony/purser-core/validators.js
+++ b/modules/node_modules/@colony/purser-core/validators.js
@@ -285,18 +285,6 @@ export const hexSequenceValidator = (hexSequence: any): boolean => {
       expression: !!hexSequence.match(MATCH.HEX_STRING),
       message: `${hexSequenceMessages.notFormat}: ${hexSequence || UNDEFINED}`,
     },
-    {
-      /*
-      * It should be under (or equal to) 1024 Bytes in size
-      *
-      * @TODO Cut down lenght check code repetition
-      *
-      * This repeats itself here and in the message length check. Might be a good
-      * idea to have "generalized" validator types
-      */
-      expression: hexSequence.length <= 1024,
-      message: `${hexSequenceMessages.tooBig}: ${hexSequence || UNDEFINED}`,
-    },
   ];
   return validatorGenerator(
     validationSequence,

--- a/modules/tests/purser-core/validators/hexSequence.test.js
+++ b/modules/tests/purser-core/validators/hexSequence.test.js
@@ -14,9 +14,6 @@ describe('`Core` Module', () => {
       expect(() => hexSequenceValidator('g')).toThrow();
       expect(() => hexSequenceValidator('h')).toThrow();
     });
-    test("Fail if it's over 1 kB in size", () => {
-      expect(() => hexSequenceValidator(String(0).repeat(1025))).toThrow();
-    });
     test("But passes if it's a valid hex sequence", () => {
       expect(hexSequenceValidator('9d1E3242221f34f7413a')).toBeTruthy();
       expect(hexSequenceValidator('12c')).toBeTruthy();


### PR DESCRIPTION
This was used to check data values were less than 1024 bytes, however lengths
greater than this are also valid. Therefore the check has been removed.

Tested with all wallets apart from Ledger, and appears to be working without problem. Particular care was taken to make sure this is working with Trezor wallets, as we believed this was why the check existed in the first place.

## TODO

- [x] Fix broken tests