### PR TITLE
Fix documentation external and internal linking

### DIFF
--- a/docs/_Interface_Common_Wallet_Interface.md
+++ b/docs/_Interface_Common_Wallet_Interface.md
@@ -65,7 +65,7 @@ Contains the wallet's public address in the form of `String`.
 
 _**Tip:** Across all wallet types and formats this is the only value that will certainly be present in the object._
 
-_**Note:** For the [Metamask Wallet](purser-metamask.md) this will always reflect the address selected from the UI, so you can always count on it to be accurate._
+_**Note:** For the [Metamask Wallet](/purser/modules-@colonypurser-metamask/) this will always reflect the address selected from the UI, so you can always count on it to be accurate._
 
 **Usage:**
 ```js
@@ -85,7 +85,7 @@ Contains the `id` of the network the wallet is intended to work on _(eg: `homest
 
 This is used on the hardware wallets to determine the `derivationPath` and on _all_ wallet types as a default if one isn't provided to the object of transaction you wish to [sign](#sign).
 
-_**Note:** For the [Metamask Wallet](purser-metamask.md) this is not available as it handles it internally, but can be changed using the UI._
+_**Note:** For the [Metamask Wallet](/purser/modules-@colonypurser-metamask/) this is not available as it handles it internally, but can be changed using the UI._
 
 **Usage:**
 ```js
@@ -235,7 +235,7 @@ This is a `getter` that returns a `Promise`. Upon resolving, the promise returns
 
 This is useful for cases where you want to prove the wallet's identity without exposing any private and dangerous information _(Eg: `privateKey`, `mnemonic`...)_.
 
-_**Note:** The [Metamask Wallet](purser-metamask.md) does not provide native access to the public key, but it can be recovered from a signed message. in order to access it, you will first have to sign a message with Metamask to obtain the public key. It will then be saved locally for future reference (current selected address only), so that if you have to use it again, you won't have re-sign the message._
+_**Note:** The [Metamask Wallet](/purser/modules-@colonypurser-metamask/) does not provide native access to the public key, but it can be recovered from a signed message. in order to access it, you will first have to sign a message with Metamask to obtain the public key. It will then be saved locally for future reference (current selected address only), so that if you have to use it again, you won't have re-sign the message._
 
 **Usage:**
 ```js

--- a/docs/_Modules_purser-software.md
+++ b/docs/_Modules_purser-software.md
@@ -47,19 +47,19 @@ import { create } from '@colony/purser-software'; // await create();
 await create(walletArguments: Object);
 ```
 
-This method returns a `Promise` which, upon resolving, will return new software wallet instance _(see: [Wallet Object](wallet-object.md))_.
+This method returns a `Promise` which, upon resolving, will return new software wallet instance.
 
-By default it will generate the maximum possible `entropy` _(see: [`getRandomValues`](api-utils.md#getRandomValues))_.
+By default it will generate the maximum possible `entropy` _(see: [`getRandomValues`](/purser/modules-@colonypurser-core/#getrandomvalues))_.
 
 Even though it will work out of the box, you can however, pass in custom arguments via the `walletArguments` object.
 
-See [`WalletArgumentsType`](../src/flowtypes.js#L34-L42) in [`flowtypes.js`](../src/flowtypes.js) for how the options object looks like.
+See `WalletArgumentsType` in [`flowtypes.js`](https://github.com/JoinColony/purser/blob/master/modules/node_modules/%40colony/purser-core/flowtypes.js) for how the options object looks like.
 
 ```js
 walletArguments.entropy: Uint8Array<>
 ```
 
-Provide custom randomness when creating the wallet. By default it will use a `8`-bit unsigned array of `65536` length on which it will generate random values _(see: [`getRandomValues`](api-utils.md#getRandomValues))_.
+Provide custom randomness when creating the wallet. By default it will use a `8`-bit unsigned array of `65536` length on which it will generate random values _(see: [`getRandomValues`](/purser/modules-@colonypurser-core/#getrandomvalues))_.
 
 ```js
 walletArguments.password: String

--- a/docs/_Modules_purser-software.md
+++ b/docs/_Modules_purser-software.md
@@ -124,7 +124,7 @@ This method returns a `Promise`, which after unlocking it via one of the availab
 
 It will not work without any arguments so you must specify at least one method of opening the wallet. If at least one is not provided, the `Promise` will `reject`, throwing an error.
 
-See [`WalletArgumentsType`](../src/flowtypes.js#L34-L42) in [`flowtypes.js`](../src/flowtypes.js) for how the options object looks like.
+See `WalletArgumentsType` in [`flowtypes.js`](https://github.com/JoinColony/purser/blob/master/modules/node_modules/%40colony/purser-core/flowtypes.js) for how the options object looks like.
 
 ```js
 walletArguments.privateKey: String


### PR DESCRIPTION
This PR fixes the various links scattered through the docs, which turned out to 404.

Fixes:
- [x] `Common Wallet Interface` links to internal `purser-metamask`
- [x] `purser-software` `create` method links to external github `flowtypes`
- [x] `purser-software` `open` method links to external github `flowtypes`