### PR TITLE
Improve NPM release script

### DIFF
--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -56,11 +56,17 @@ for module in $(ls "${MODULES_PATH}"); do
     continue
   fi
   cd "${MODULES_PATH}/$module/lib"
+  CURRENT_VERSION=$(node -p "require('./package.json').version")
+  VERSION_PUBLISHED=$(npm view "@colony/$module@$CURRENT_VERSION" version)
+  if [ $VERSION_PUBLISHED ]; then
+    echo "@colony/$module @ $CURRENT_VERSION is already published, skipping"
+    continue
+  fi
   if [ ! -z $JUST_A_TEST ]; then
-    log "Packing @colony/$module to NPM..."
+    log "Packing @colony/$module @ $CURRENT_VERSION to NPM..."
     npm pack
   else
-    log "Publishing @colony/$module to NPM..."
+    log "Publishing @colony/$module @ $CURRENT_VERSION to NPM..."
     npm publish --access public
   fi
   cd "${ROOT_PATH}"

--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -6,6 +6,10 @@
 
 set -e
 
+# Login (for this release session)
+# Since this script will most likely run a different shell environment than your normal terminal
+npm adduser
+
 # Paths
 ROOT_PATH=$(pwd)
 MODULES_PATH="${ROOT_PATH}/modules/node_modules/@colony"

--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -66,8 +66,19 @@ for module in $(ls "${MODULES_PATH}"); do
     log "Packing @colony/$module @ $CURRENT_VERSION to NPM..."
     npm pack
   else
-    log "Publishing @colony/$module @ $CURRENT_VERSION to NPM..."
-    npm publish --access public
+    if [ $(echo $CURRENT_VERSION | grep "rc") ]; then
+      log "Publishing @colony/$module @ $CURRENT_VERSION to NPM as RELEASE CANDIDATE"
+      npm publish --access public --tag rc
+    elif [ $(echo $CURRENT_VERSION | grep "beta") ]; then
+      log "Publishing @colony/$module @ $CURRENT_VERSION to NPM as BETA"
+      npm publish --access public --tag beta
+    elif [ $(echo $CURRENT_VERSION | grep "alpha") ]; then
+      log "Publishing @colony/$module @ $CURRENT_VERSION to NPM as ALPHA"
+      npm publish --access public --tag alpha
+    else
+      log "Publishing @colony/$module @ $CURRENT_VERSION to NPM"
+      npm publish --access public
+    fi
   fi
   cd "${ROOT_PATH}"
 done

--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -56,25 +56,32 @@ for module in $(ls "${MODULES_PATH}"); do
     continue
   fi
   cd "${MODULES_PATH}/$module/lib"
+  # Get the current LOCAL package version
   CURRENT_VERSION=$(node -p "require('./package.json').version")
+  # Check if that version is already published
   VERSION_PUBLISHED=$(npm view "@colony/$module@$CURRENT_VERSION" version)
   if [ $VERSION_PUBLISHED ]; then
     echo "@colony/$module @ $CURRENT_VERSION is already published, skipping"
     continue
   fi
+  # If we're just testing, create a archive containing the release files, but don't push them
   if [ ! -z $JUST_A_TEST ]; then
     log "Packing @colony/$module @ $CURRENT_VERSION to NPM..."
     npm pack
   else
+    # Do a RC release
     if [ $(echo $CURRENT_VERSION | grep "rc") ]; then
       log "Publishing @colony/$module @ $CURRENT_VERSION to NPM as RELEASE CANDIDATE"
       npm publish --access public --tag rc
+    # Do a BETA release
     elif [ $(echo $CURRENT_VERSION | grep "beta") ]; then
       log "Publishing @colony/$module @ $CURRENT_VERSION to NPM as BETA"
       npm publish --access public --tag beta
+    # DO an ALPHA release
     elif [ $(echo $CURRENT_VERSION | grep "alpha") ]; then
       log "Publishing @colony/$module @ $CURRENT_VERSION to NPM as ALPHA"
       npm publish --access public --tag alpha
+    # DO a normal (LATEST) release
     else
       log "Publishing @colony/$module @ $CURRENT_VERSION to NPM"
       npm publish --access public


### PR DESCRIPTION
This PR adds a couple of improvements to the release scripts so that we won't have to change it by hand every time we do a release. _(latest releases were all done this way...)_

Changes:
- [x] Add login step, so every time you run it, you'll get a prompt to login
- [x] Check if the current version is already published, and if so, skip trying to push it again
- [x] Check if the package version is tagged _(eg: `beta`, `alpha`, `rc`)_ and release it under that tag

While it's not really feasible _(from a UX point of view)_ to a global OTP code to the release, we've done the next best thing, and add a login step + getting prompted before each package push, and as such, this also resolves #127 