### PR TITLE
Add support for `messageData` options for `signMessage`

### DIFF
--- a/docs/_Interface_Common_Wallet_Interface.md
+++ b/docs/_Interface_Common_Wallet_Interface.md
@@ -390,14 +390,15 @@ Sign a message with your public key to prove your identity and ownership of the 
 
 This method takes in an `messageObject` Object _(See below)_, and returns the hex `String` signature wrapped inside a `Promise` _(This method is `async`)_.
 
-The `messageObject` only has one prop, `message`, but to keep consistency with the rest of the library, it is passed in as an Object.
+The `messageObject` must contain exactly one of either `message` or `messageData`, where `message` is a UTF-8 string and `messageData` is the raw data to be signed as either a hex string (`0x...`) or a `Uint8Array`.
 
 _**Note**: On hardware wallets this method will require some form of confirmation from the user._
 
 **`messageObject` format:**
 ```js
 messageObject {
-  message: String // The message you want to sign, as a String. Defaults to the '' empty String
+  message?: String // The message you want to sign, as a String. Defaults to the '' empty String
+  messageData?: String | Uint8Array
 }
 ```
 
@@ -408,6 +409,9 @@ import { open } from '@colony/purser-trezor';
 const trezorWallet = await open();
 
 const messageSignature = await trezorWallet.signMessage({ message: 'Yes, this is me!' }); // '0xa1f7...0b1c'
+
+const messageData = new Uint8Array('some arbitrary data');
+const messageSignatureFromData = await trezorWallet.signMessage({ messageData }); // 0x...'
 ```
 
 ### `verifyMessage()`

--- a/modules/node_modules/@colony/purser-core/defaults.js
+++ b/modules/node_modules/@colony/purser-core/defaults.js
@@ -133,6 +133,9 @@ export const NETWORK_IDS: Object = {
  * Prop names used to validate user input against
  */
 export const REQUIRED_PROPS: Object = {
-  SIGN_MESSAGE: ['message'],
+  /*
+   * Exactly one of these
+   */
+  SIGN_MESSAGE: ['message', 'messageData'],
   VERIFY_MESSAGE: ['message', 'signature'],
 };

--- a/modules/node_modules/@colony/purser-core/helpers.js
+++ b/modules/node_modules/@colony/purser-core/helpers.js
@@ -8,6 +8,7 @@ import {
   addressValidator,
   hexSequenceValidator,
   messageValidator,
+  messageDataValidator,
 } from './validators';
 import { hexSequenceNormalizer, recoveryParamNormalizer } from './normalizers';
 import { bigNumber, warning } from './utils';
@@ -324,10 +325,12 @@ export const userInputValidator = ({
   firstArgument = {},
   requiredEither = [],
   requiredAll = [],
+  requiredOr = [],
 }: {
   firstArgument: Object,
   requiredAll?: Array<String>,
   requiredEither?: Array<String>,
+  requiredOr?: Array<String>,
 } = {}): void => {
   const { userInputValidator: messages } = helperMessages;
   /*
@@ -374,7 +377,42 @@ export const userInputValidator = ({
     }
     return propName;
   });
+  /*
+   * Check if exactly one of the required props is present.
+   * Fail if multiple are present.
+   */
+  if (
+    requiredOr.length &&
+    requiredOr.reduce(
+      (acc, propName) =>
+        Object.prototype.hasOwnProperty.call(firstArgument, propName)
+          ? acc + 1
+          : acc,
+        0,
+    ) !== 1
+  ) {
+    warning(messages.argumentsFormatExplanation);
+    throw new Error();
+  }
 };
+
+export const messageOrDataValidator = (
+  { message, messageData }:
+  { message: any, messageData: any }
+): string | Uint8Array => {
+  if (message) {
+    messageValidator(message);
+    return message;
+  } 
+  messageDataValidator(messageData);
+  return typeof messageData === 'string'
+    ? new Uint8Array(Buffer.from(
+        hexSequenceNormalizer(messageData, false),
+        'hex',
+      ))
+    : messageData;
+  
+}
 
 /*
  * This default export is only here to help us with testing, otherwise
@@ -387,6 +425,7 @@ const coreHelpers: Object = {
   transactionObjectValidator,
   messageVerificationObjectValidator,
   userInputValidator,
+  messageOrDataValidator,
 };
 
 export default coreHelpers;

--- a/modules/node_modules/@colony/purser-core/validators.js
+++ b/modules/node_modules/@colony/purser-core/validators.js
@@ -329,3 +329,33 @@ export const messageValidator = (string: any): boolean => {
     `${messageMessages.genericError}: ${string || UNDEFINED}`,
   );
 };
+
+
+/**
+ * Validate a hex string
+ *
+ * @method messageDataValidator
+ *
+ * @param {any} data The messageData to check
+ *
+ * @return {boolean} It only returns true if the data is a valid format,
+ * otherwise an Error will be thrown and this will not finish execution.
+ */
+export const messageDataValidator = (data: any): boolean => {
+  const { message: messageMessages } = messages;
+  const validationSequence: Array<Object> = [
+    {
+      /*
+      * It should be a hex string or UInt8Array
+      */
+      expression: (typeof data === 'string' && hexSequenceValidator(data)) ||
+        data.constructor === Uint8Array,
+      message: `${messageMessages.notString}: ${objectToErrorString(data) ||
+        UNDEFINED}`,
+    },
+  ];
+  return validatorGenerator(
+    validationSequence,
+    `${messageMessages.genericError}: ${data || UNDEFINED}`,
+  );
+};

--- a/modules/node_modules/@colony/purser-ledger/class.js
+++ b/modules/node_modules/@colony/purser-ledger/class.js
@@ -52,11 +52,12 @@ export default class LedgerWallet extends GenericWallet {
              */
             userInputValidator({
               firstArgument: messageObject,
-              requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+              requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
             });
             return signMessage({
               derivationPath: await this.derivationPath,
               message: messageObject.message,
+              messageData: messageObject.messageData,
             });
           },
         },

--- a/modules/node_modules/@colony/purser-ledger/staticMethods.js
+++ b/modules/node_modules/@colony/purser-ledger/staticMethods.js
@@ -4,7 +4,6 @@ import EthereumTx from 'ethereumjs-tx';
 
 import {
   derivationPathValidator,
-  messageValidator,
   hexSequenceValidator,
 } from '@colony/purser-core/validators';
 import {
@@ -18,6 +17,7 @@ import {
   verifyMessageSignature,
   transactionObjectValidator,
   messageVerificationObjectValidator,
+  messageOrDataValidator,
 } from '@colony/purser-core/helpers';
 import { HEX_HASH_TYPE, SIGNATURE } from '@colony/purser-core/defaults';
 import { ledgerConnection, handleLedgerConnectionError } from './helpers';
@@ -212,13 +212,14 @@ export const signTransaction = async ({
  */
 export const signMessage = async ({
   derivationPath,
-  message = ' ',
+  message,
+  messageData,
 }: Object = {}): Promise<string | void> => {
   /*
    * Validate input values: derivationPath and message
    */
   derivationPathValidator(derivationPath);
-  messageValidator(message);
+  const toSign = messageOrDataValidator({ message, messageData });
   try {
     const ledger: LedgerInstanceType = await ledgerConnection();
     /*
@@ -243,7 +244,7 @@ export const signMessage = async ({
        * Also, Flow don't know about Buffer
        */
       /* $FlowFixMe */
-      Buffer.from(message).toString(HEX_HASH_TYPE),
+      Buffer.from(toSign).toString(HEX_HASH_TYPE),
     );
     /*
      * Combine the (R), and (S) signature components, alogn with the reco(V)ery param (that
@@ -257,7 +258,7 @@ export const signMessage = async ({
   } catch (caughtError) {
     return handleLedgerConnectionError(
       caughtError,
-      `${messages.userSignTxGenericError}: message: (${message}) ${
+      `${messages.userSignTxGenericError}: message: (${toSign.toString()}) ${
         caughtError.message
       }`,
     );

--- a/modules/node_modules/@colony/purser-metamask/class.js
+++ b/modules/node_modules/@colony/purser-metamask/class.js
@@ -111,11 +111,12 @@ export default class MetamaskWallet {
              */
             userInputValidator({
               firstArgument: messageObject,
-              requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+              requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
             });
             return signMessage({
               currentAddress: this.address,
               message: messageObject.message,
+              messageData: messageObject.messageData,
             });
           },
         },

--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -8,7 +8,6 @@ import {
   hexSequenceValidator,
   addressValidator,
   safeIntegerValidator,
-  messageValidator,
 } from '@colony/purser-core/validators';
 import {
   addressNormalizer,
@@ -17,6 +16,7 @@ import {
 import {
   transactionObjectValidator,
   messageVerificationObjectValidator,
+  messageOrDataValidator,
 } from '@colony/purser-core/helpers';
 
 import { HEX_HASH_TYPE } from '@colony/purser-core/defaults';
@@ -202,9 +202,10 @@ export const signTransaction = async ({
 export const signMessage = async ({
   currentAddress,
   message,
+  messageData
 }: Object = {}): Promise<string | void> => {
   addressValidator(currentAddress);
-  messageValidator(message);
+  const toSign = messageOrDataValidator({ message, messageData });
   /*
    * We must check for the Metamask injected in-page proxy every time we
    * try to access it. This is because something can change it from the time
@@ -229,7 +230,7 @@ export const signMessage = async ({
              * We could really do with default Flow types for Buffer...
              */
             /* $FlowFixMe */
-            Buffer.from(message).toString(HEX_HASH_TYPE),
+            Buffer.from(toSign).toString(HEX_HASH_TYPE),
           ),
           currentAddress,
           /*

--- a/modules/node_modules/@colony/purser-software/class.js
+++ b/modules/node_modules/@colony/purser-software/class.js
@@ -172,10 +172,11 @@ export default class SoftwareWallet {
              */
             userInputValidator({
               firstArgument: messageObject,
-              requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+              requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
             });
             return signMessage({
               message: messageObject.message,
+              messageData: messageObject.messageData,
               /*
                * @NOTE We need to bind the whole ethers instance
                *

--- a/modules/node_modules/@colony/purser-software/staticMethods.js
+++ b/modules/node_modules/@colony/purser-software/staticMethods.js
@@ -8,13 +8,13 @@ import {
 import {
   transactionObjectValidator,
   messageVerificationObjectValidator,
+  messageOrDataValidator,
 } from '@colony/purser-core/helpers';
 import {
   addressNormalizer,
   hexSequenceNormalizer,
 } from '@colony/purser-core/normalizers';
 import {
-  messageValidator,
   addressValidator,
 } from '@colony/purser-core/validators';
 import { objectToErrorString } from '@colony/purser-core/utils';
@@ -102,21 +102,23 @@ export const signTransaction = async ({
  * @method signMessage
  *
  * @param {string} message the message you want to sign
+ * @param {string} messageData the message you want to sign
  * @param {function} callback Ethers method to call with the validated message string
  *
- * All the above params are sent in as props of an {object}.
+ * All the above params are sent in as props of an {object}. Note that only one
+ * of message or messageData can be set (enforced in class).
  *
  * @return {Promise<string>} The signed message `hex` string (wrapped inside a `Promise`)
  */
-export const signMessage = async ({ message, callback }: Object = {}): Promise<
-  string,
-> => {
+export const signMessage = async (
+  { message, messageData, callback }: Object = {},
+): Promise<string> => {
   /*
    * Validate input value
    */
-  messageValidator(message);
+  const toSign = messageOrDataValidator({ message, messageData });
   try {
-    const messageSignature: string = await callback(message);
+    const messageSignature: string = await callback(toSign);
     /*
      * Normalize the message signature
      */

--- a/modules/node_modules/@colony/purser-trezor/class.js
+++ b/modules/node_modules/@colony/purser-trezor/class.js
@@ -77,11 +77,12 @@ export default class TrezorWallet extends GenericWallet {
              */
             userInputValidator({
               firstArgument: messageObject,
-              requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+              requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
             });
             return signMessage({
               derivationPath: await this.derivationPath,
               message: messageObject.message,
+              messageData: messageObject.messageData,
             });
           },
         },

--- a/modules/node_modules/@colony/purser-trezor/staticMethods.js
+++ b/modules/node_modules/@colony/purser-trezor/staticMethods.js
@@ -6,7 +6,6 @@ import EthereumTx from 'ethereumjs-tx';
 import {
   addressValidator,
   derivationPathValidator,
-  messageValidator,
 } from '@colony/purser-core/validators';
 import {
   derivationPathNormalizer,
@@ -22,6 +21,7 @@ import {
 import {
   transactionObjectValidator,
   messageVerificationObjectValidator,
+  messageOrDataValidator,
 } from '@colony/purser-core/helpers';
 
 import { HEX_HASH_TYPE, SIGNATURE } from '@colony/purser-core/defaults';
@@ -286,13 +286,14 @@ export const signTransaction = async ({
  */
 export const signMessage = async ({
   derivationPath,
-  message = ' ',
+  message,
+  messageData,
 }: Object = {}): Promise<string | void> => {
   /*
    * Validate input values: derivationPath and message
    */
   derivationPathValidator(derivationPath);
-  messageValidator(message);
+  const toSign = messageOrDataValidator({ message, messageData });
   warning(messages.messageSignatureOnlyTrezor);
   try {
     const { signature: signedMessage } = await payloadListener({
@@ -308,7 +309,8 @@ export const signMessage = async ({
           derivationPathNormalizer(derivationPath),
           true,
         ).toPathArray(),
-        message,
+        // $FlowFixMe need Buffer types
+        message: Buffer.from(toSign).toString(HEX_HASH_TYPE),
       }),
     });
     /*

--- a/modules/tests/mocks/@colony/purser-core/helpers.js
+++ b/modules/tests/mocks/@colony/purser-core/helpers.js
@@ -19,3 +19,12 @@ export const verifyMessageSignature = jest.fn();
 export const recoverPublicKey = jest.fn(() => 'recovered-mocked-public-key');
 
 export const userInputValidator = jest.fn();
+
+export const messageOrDataValidator = jest.fn(
+  ({ message, messageData } = {}) => {
+    if (message) {
+      return message;
+    }
+    return messageData;
+  },
+);

--- a/modules/tests/purser-ledger/class.test.js
+++ b/modules/tests/purser-ledger/class.test.js
@@ -182,7 +182,7 @@ describe('Ledger` Hardware Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedMessageObject,
-        requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+        requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
       });
     });
     test(

--- a/modules/tests/purser-ledger/staticMethods/signMessage.test.js
+++ b/modules/tests/purser-ledger/staticMethods/signMessage.test.js
@@ -7,6 +7,7 @@ import {
   derivationPathValidator,
   messageValidator,
 } from '@colony/purser-core/validators';
+import { messageOrDataValidator } from '@colony/purser-core/helpers';
 
 import { signMessage } from '@colony/purser-ledger/staticMethods';
 import {
@@ -78,8 +79,10 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
       /*
        * Validates the message string
        */
-      expect(messageValidator).toHaveBeenCalled();
-      expect(messageValidator).toHaveBeenCalledWith(message);
+      expect(messageOrDataValidator).toHaveBeenCalled();
+      expect(messageOrDataValidator).toHaveBeenCalledWith(
+        expect.objectContaining({ message }),
+      );
     });
     test('Normalizes the derivation path before sending', async () => {
       await signMessage(mockedArgumentsObject);
@@ -114,7 +117,7 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
        * an error along the way
        */
       ledgerConnection.mockRejectedValueOnce(new Error());
-      await signMessage();
+      await signMessage(mockedArgumentsObject);
       /*
        * Handles the specific transport error
        */

--- a/modules/tests/purser-metamask/class.test.js
+++ b/modules/tests/purser-metamask/class.test.js
@@ -277,7 +277,7 @@ describe('Metamask` Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockeMessageObject,
-        requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+        requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
       });
     });
     test('Calls the correct method to verify a message', async () => {

--- a/modules/tests/purser-metamask/staticMethods/signMessage.test.js
+++ b/modules/tests/purser-metamask/staticMethods/signMessage.test.js
@@ -8,12 +8,14 @@ import {
   messageValidator,
   hexSequenceValidator,
 } from '@colony/purser-core/validators';
+import { messageOrDataValidator } from '@colony/purser-core/helpers';
 
 import { STD_ERRORS } from '@colony/purser-metamask/defaults';
 
 jest.dontMock('@colony/purser-metamask/staticMethods');
 
 jest.mock('@colony/purser-core/validators');
+jest.mock('@colony/purser-core/helpers');
 /*
  * @TODO Fix manual mocks
  * This is needed since Jest won't see our manual mocks (because of our custom monorepo structure)
@@ -123,8 +125,12 @@ describe('`Metamask` Wallet Module Static Methods', () => {
       /*
        * Calls the validation helper with the correct values
        */
-      expect(messageValidator).toHaveBeenCalled();
-      expect(messageValidator).toHaveBeenCalledWith(mockedMessage);
+      expect(messageOrDataValidator).toHaveBeenCalled();
+      expect(messageOrDataValidator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: mockedMessage,
+        }),
+      );
     });
     test('Normalizes the message before sending it to Metamask', async () => {
       await signMessage(mockedArgumentsObject);

--- a/modules/tests/purser-metamask/staticMethods/signMessage.test.js
+++ b/modules/tests/purser-metamask/staticMethods/signMessage.test.js
@@ -15,7 +15,6 @@ import { STD_ERRORS } from '@colony/purser-metamask/defaults';
 jest.dontMock('@colony/purser-metamask/staticMethods');
 
 jest.mock('@colony/purser-core/validators');
-jest.mock('@colony/purser-core/helpers');
 /*
  * @TODO Fix manual mocks
  * This is needed since Jest won't see our manual mocks (because of our custom monorepo structure)

--- a/modules/tests/purser-software/class.test.js
+++ b/modules/tests/purser-software/class.test.js
@@ -310,7 +310,7 @@ describe('`Software` Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedMessageObject,
-        requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+        requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
       });
     });
     test('`verifyMessages()` calls the correct static method', async () => {

--- a/modules/tests/purser-software/staticMethods/signMessage.test.js
+++ b/modules/tests/purser-software/staticMethods/signMessage.test.js
@@ -2,6 +2,7 @@ import { hexSequenceNormalizer } from '@colony/purser-core/normalizers';
 import { messageValidator } from '@colony/purser-core/validators';
 
 import { signMessage } from '@colony/purser-software/staticMethods';
+import { messageOrDataValidator } from '@colony/purser-core/helpers';
 
 jest.dontMock('@colony/purser-software/staticMethods');
 
@@ -51,8 +52,12 @@ describe('`Software` Wallet Module', () => {
     });
     test('Validates the message string', async () => {
       await signMessage(mockedArgumentsObject);
-      expect(messageValidator).toHaveBeenCalled();
-      expect(messageValidator).toHaveBeenCalledWith(mockedMessage);
+      expect(messageOrDataValidator).toHaveBeenCalled();
+      expect(messageOrDataValidator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: mockedMessage,
+        }),
+      );
     });
     test('Normalizes the message signature before returning', async () => {
       await signMessage(mockedArgumentsObject);

--- a/modules/tests/purser-trezor/class.test.js
+++ b/modules/tests/purser-trezor/class.test.js
@@ -176,7 +176,7 @@ describe('Trezor` Hardware Wallet Module', () => {
       expect(userInputValidator).toHaveBeenCalled();
       expect(userInputValidator).toHaveBeenCalledWith({
         firstArgument: mockedMessageObject,
-        requiredAll: REQUIRED_PROPS.SIGN_MESSAGE,
+        requiredOr: REQUIRED_PROPS.SIGN_MESSAGE,
       });
     });
     test(

--- a/modules/tests/purser-trezor/staticMethods/signMessage.test.js
+++ b/modules/tests/purser-trezor/staticMethods/signMessage.test.js
@@ -7,6 +7,7 @@ import {
   messageValidator,
 } from '@colony/purser-core/validators';
 import { warning } from '@colony/purser-core/utils';
+import { messageOrDataValidator } from '@colony/purser-core/helpers';
 
 import { signMessage } from '@colony/purser-trezor/staticMethods';
 import { payloadListener } from '@colony/purser-trezor/helpers';
@@ -59,7 +60,7 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
          * If the validators wouldn't be mocked, they wouldn't pass.
          */
         path: 0,
-        mesasge: 0,
+        message: Buffer.from([]),
       });
       expect(payloadListener).toHaveBeenCalled();
       expect(payloadListener).toHaveBeenCalledWith({
@@ -86,8 +87,10 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
       /*
        * Validates the message string
        */
-      expect(messageValidator).toHaveBeenCalled();
-      expect(messageValidator).toHaveBeenCalledWith(message);
+      expect(messageOrDataValidator).toHaveBeenCalled();
+      expect(messageOrDataValidator).toHaveBeenCalledWith(
+        expect.objectContaining({ message }),
+      );
     });
     test('Normalizes the derivation path before sending', async () => {
       await signMessage(mockedMessageObject);
@@ -106,9 +109,7 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
       payloadListener.mockImplementation(() => ({
         signature: returnedHexString,
       }));
-      await signMessage({
-        derivationPath,
-      });
+      await signMessage(mockedMessageObject);
       /*
        * Normalizes the return string
        */


### PR DESCRIPTION
When calling `signMessage`, it is now possible to pass either `message` or
`messageData`. The latter can be a valid hex string or Uint8Array, and will be
passed to the underlying wallet without any additional encoding.

This solves scenarios where you wish to sign arbitrary data which cannot be represented as a UTF-8 string.

## TODO

- [x] Make tests pass
- [x] Add documentation
- [ ] Open issue to support `messageData` with `verifyMessage`

Closes #192 