### PR TITLE
Release 2.1.1 Hotfix

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/package.json
+++ b/modules/node_modules/@colony/purser-metamask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/purser-metamask",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A javascript library to interact with a Metamask based Ethereum wallet",
   "keywords": [
     "metamask",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purser",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Interact with Ethereum wallets easily",
   "scripts": {
     "build": "node scripts/build-all-modules.js",


### PR DESCRIPTION
This PR bumps the `monorepo` and `purser-metamask` to they're new version, in preparation for the upcoming hotfix release.