### PR TITLE
Upgrade `@ledgerhq/hw-transport-u2f` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "@ledgerhq/hw-app-eth": "^4.19.0",
-    "@ledgerhq/hw-transport-u2f": "^4.20.0",
+    "@ledgerhq/hw-transport-u2f": "^4.50.0",
     "bip32-path": "^0.4.2",
     "bn.js": "^4.11.8",
     "ethereumjs-tx": "^1.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,23 +778,46 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@kironeducation/flow-junit-transformer/-/flow-junit-transformer-0.3.0.tgz#ea1e57b01d7096012254a3d3dafc8afc7d97b8fe"
 
+"@ledgerhq/devices@^4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.50.0.tgz#3a1b762948fd3720e73eafad4767d18a903a4b05"
+  integrity sha512-Dtk3IiaNV2lMnfCABWx7+wJsOiJIzEUT6/1a5f1+g5vZoXf+3v+Bop7GB3ob/Xtfkxjk7wrlsglT8B/TrEVk3Q==
+  dependencies:
+    "@ledgerhq/errors" "^4.50.0"
+
+"@ledgerhq/errors@^4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.50.0.tgz#d330e396d47bbbe474fe0adfa087eeb7edd76912"
+  integrity sha512-Xg5GTDUWprVJ5zCWtfESLfI1qyr09JQH8pLtWDCkz3GxlwnFPtMAvKB9qUoc2Ou4zJ9DfsZdS8KaZ/2VKXkYGA==
+
 "@ledgerhq/hw-app-eth@^4.19.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.24.0.tgz#b62514e0d18672d6d35d76dfbeaf93b67d2e5324"
   dependencies:
     "@ledgerhq/hw-transport" "^4.24.0"
 
-"@ledgerhq/hw-transport-u2f@^4.20.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.28.0.tgz#5cee76c39c2972e22864992585a52b6a1fb8bc52"
+"@ledgerhq/hw-transport-u2f@^4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.50.0.tgz#31605d3d40f8303cc26260d54b75ef0b6f96e752"
+  integrity sha512-/J//nWNshyxgUjdxw69eOVtd0QQa93knEOikgN0INmL2A0ozNQl8vTNxqIWEpKW+XhJbdq4ep35p4g5eIcgKQw==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.24.0"
+    "@ledgerhq/errors" "^4.50.0"
+    "@ledgerhq/hw-transport" "^4.50.0"
     u2f-api "0.2.7"
 
 "@ledgerhq/hw-transport@^4.24.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.24.0.tgz#8def925d8c2e1f73d15128d9e27ead729870be58"
   dependencies:
+    events "^3.0.0"
+
+"@ledgerhq/hw-transport@^4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.50.0.tgz#2b4c8e9954a9fe7e616cb936ae105fa1de776095"
+  integrity sha512-NDbTOkoAphL9er46wjni2CVn+s8ZfyDVgj2dVS00L/NYA3ajVX21DrRGMEI8P5/kdLx4KfID4Z1wsa6Hefj3EQ==
+  dependencies:
+    "@ledgerhq/devices" "^4.50.0"
+    "@ledgerhq/errors" "^4.50.0"
     events "^3.0.0"
 
 "@samverschueren/stream-to-observable@^0.3.0":


### PR DESCRIPTION
This PR manually updates the `@ledgerhq/hw-transport-u2f` dependency package to version `4.50.0` due to some initial build failing on CI when `greenkeeper` attempted to do this automatically.

Resolves #216 