### PR TITLE
LedgerWallet work with other coin-types than just Eth

### DIFF
--- a/modules/node_modules/@colony/purser-core/flowtypes.js
+++ b/modules/node_modules/@colony/purser-core/flowtypes.js
@@ -56,6 +56,7 @@ export type WalletArgumentsType = {
   entropy?: Uint8Array,
   password?: string,
   chainId?: number,
+  coinType?: number,
   sign?: () => {},
   signMessage?: () => {},
 };

--- a/modules/node_modules/@colony/purser-ledger/index.js
+++ b/modules/node_modules/@colony/purser-ledger/index.js
@@ -38,7 +38,7 @@ export const open = async (
   userInputValidator({
     firstArgument: argumentObject,
   });
-  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  const { addressCount, coinType, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
   /*
    * @TODO Reduce code repetition
    * By moving this inside a helper. This same patter will be used on the
@@ -47,7 +47,7 @@ export const open = async (
    * If we're on a testnet set the coin type id to `1`
    * This will be used in the derivation path
    */
-  const coinType: number =
+  const defaultCoinType: number =
     chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
   /*
    * Get to root derivation path based on the coin type.
@@ -56,7 +56,7 @@ export const open = async (
    * (inside the class constructor)
    */
   const rootDerivationPath: string = derivationPathSerializer({
-    coinType,
+    coinType: coinType || defaultCoinType,
   });
   try {
     const ledger: LedgerInstanceType = await ledgerConnection();


### PR DESCRIPTION
Here at Tomochain we build our own blockchain from a fork of ETH, so it would be so nice if I can use `purser-ledger` to work with our blockchain app.