### PR TITLE
LedgerWallet working with other coin-types than just Eth

### DIFF
--- a/modules/node_modules/@colony/purser-core/flowtypes.js
+++ b/modules/node_modules/@colony/purser-core/flowtypes.js
@@ -56,6 +56,7 @@ export type WalletArgumentsType = {
   entropy?: Uint8Array,
   password?: string,
   chainId?: number,
+  coinType?: number,
   sign?: () => {},
   signMessage?: () => {},
 };

--- a/modules/node_modules/@colony/purser-ledger/index.js
+++ b/modules/node_modules/@colony/purser-ledger/index.js
@@ -38,7 +38,11 @@ export const open = async (
   userInputValidator({
     firstArgument: argumentObject,
   });
-  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  const {
+    addressCount,
+    coinType,
+    chainId = NETWORK_IDS.HOMESTEAD,
+  } = argumentObject;
   /*
    * @TODO Reduce code repetition
    * By moving this inside a helper. This same patter will be used on the
@@ -47,7 +51,7 @@ export const open = async (
    * If we're on a testnet set the coin type id to `1`
    * This will be used in the derivation path
    */
-  const coinType: number =
+  const defaultCoinType: number =
     chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
   /*
    * Get to root derivation path based on the coin type.
@@ -56,7 +60,7 @@ export const open = async (
    * (inside the class constructor)
    */
   const rootDerivationPath: string = derivationPathSerializer({
-    coinType,
+    coinType: coinType || defaultCoinType,
   });
   try {
     const ledger: LedgerInstanceType = await ledgerConnection();

--- a/modules/node_modules/@colony/purser-trezor/index.js
+++ b/modules/node_modules/@colony/purser-trezor/index.js
@@ -43,7 +43,11 @@ export const open = async (
   userInputValidator({
     firstArgument: argumentObject,
   });
-  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  const {
+    addressCount,
+    coinType,
+    chainId = NETWORK_IDS.HOMESTEAD,
+  } = argumentObject;
   /*
    * @TODO Reduce code repetition
    * By moving this inside a helper. This same patter will be used on the
@@ -52,7 +56,7 @@ export const open = async (
    * If we're on a testnet set the coin type id to `1`
    * This will be used in the derivation path
    */
-  const coinType: number =
+  const defaultCoinType: number =
     chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
   /*
    * Get to root derivation path based on the coin type.
@@ -62,7 +66,7 @@ export const open = async (
    */
   const rootDerivationPath: string = derivationPathSerializer({
     change: PATH.CHANGE,
-    coinType,
+    coinType: coinType || defaultCoinType,
   });
   /*
    * Modify the default payload to overwrite the path with the new


### PR DESCRIPTION
Here at TomoChain we're building a new blockchain based on Ethereum, thus we need to make Ledger work with it. It would be nice if we can specify which coin-type Purser-Ledger needs to work with other than just default Ethereum.