### PR TITLE
purser-metamask will throw when cancelling signing a message or transaction

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -172,11 +172,11 @@ export const signTransaction = async ({
               return resolve(normalizedSignedTransaction);
             } catch (caughtError) {
               /*
-               * Don't throw an Error if the user just cancels signing transaction.
-               * This is normal UX, not an exception
+               * If the user cancels signing the transaction we still throw,
+               * but we customize the message
                */
               if (error.message.includes(STD_ERRORS.CANCEL_TX_SIGN)) {
-                return warning(messages.cancelTransactionSign);
+                throw new Error(messages.cancelTransactionSign);
               }
               throw new Error(error.message);
             }

--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -252,11 +252,11 @@ export const signMessage = async ({
               return resolve(normalizedSignature);
             } catch (caughtError) {
               /*
-               * Don't throw an Error if the user just cancels signing the message.
-               * This is normal UX, not an exception
+               * If the user cancels signing the message we still throw,
+               * but we customize the message
                */
               if (error.message.includes(STD_ERRORS.CANCEL_MSG_SIGN)) {
-                return warning(messages.cancelMessageSign);
+                throw new Error(messages.cancelMessageSign);
               }
               throw new Error(error.message);
             }

--- a/modules/tests/purser-metamask/staticMethods/signMessage.test.js
+++ b/modules/tests/purser-metamask/staticMethods/signMessage.test.js
@@ -184,8 +184,7 @@ describe('`Metamask` Wallet Module Static Methods', () => {
             mockedMessageSignature,
           ),
       );
-      expect(() => signMessage(mockedArgumentsObject)).not.toThrow();
-      expect(warning).toHaveBeenCalled();
+      expect(signMessage(mockedArgumentsObject)).rejects.toThrow();
     });
   });
 });

--- a/modules/tests/purser-metamask/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-metamask/staticMethods/signTransaction.test.js
@@ -211,7 +211,7 @@ describe('`Metamask` Wallet Module Static Methods', () => {
       });
       expect(signTransaction(mockedArgumentsObject)).rejects.toThrow();
     });
-    test('Warns if the user cancelled signing the message', async () => {
+    test('Throws if the user cancelled signing the message', async () => {
       /*
        * Mock it locally to simulate an error
        */
@@ -225,8 +225,7 @@ describe('`Metamask` Wallet Module Static Methods', () => {
             mockedTransactionHash,
           ),
       );
-      expect(() => signTransaction(mockedArgumentsObject)).not.toThrow();
-      expect(warning).toHaveBeenCalled();
+      expect(signTransaction(mockedArgumentsObject)).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
Due to the need to properly detect when a user has cancelled signing a transaction, throwing an error is better then just logging a warning.

As such, we've changed `purser-metamask` to throw on each instance where a user cancels, either signing a message, or a transaction.

*Changes*

- [x] `purser-metamask` static `signTransaction` now throws a custom message when the user cancels
- [x] `purser-metamask` static `signMessage` now throws a custom message when the user cancels
- [x] Fixed both unit tests related to the above changes
