### PR TITLE
Upgrade `eslint-plugin-flowtype` to version `3.11.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint": "6.0.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-flowtype": "^3.4.2",
+    "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-prettier": "^3.0.0",
     "find-imports": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,10 +2324,10 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-plugin-flowtype@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.4.2.tgz#55475e10b05fd714d60bceebbbed596cb8706b16"
-  integrity sha512-sv6O6fiN3dIwhU4qRxfcyIpbKGVvsxwIQ6vgBLudpQKjH1rEyEFEOjGzGEUBTQP9J8LdTZm37OjiqZ0ZeFOa6g==
+eslint-plugin-flowtype@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.11.1.tgz#1aae15a10dbcd5aecc89897f810f2e9fcc18a5e3"
+  integrity sha512-4NiaaGZuz9iEGRTK8j4lkA/scibOXSYaYoHbsTtgLOxxqQCkbWV3xt8ETqILKg7DAYDqB69z1H5U71UmtdF9hw==
   dependencies:
     lodash "^4.17.11"
 


### PR DESCRIPTION
This PR upgrades the `eslint-plugin-flowtype` dev dependency to version `3.11.1`.

This was done manually because GK couldn't automatically update due to a broken build.