### PR TITLE
Upgrade `ethers` to version `4.0.33`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "bn.js": "^5.0.0",
     "ethereumjs-tx": "^2.1.0",
     "ethereumjs-util": "^6.0.0",
-    "ethers": "^4.0.12",
+    "ethers": "^4.0.33",
     "hdkey": "^1.1.0",
     "lodash.isequal": "^4.5.0",
     "web3": "1.0.0-beta.36"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2533,9 +2533,10 @@ ethers@4.0.0-beta.1:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^4.0.12:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.12.tgz#290f4a5a9711feb4c573edbd991ceb6bc5cec39b"
+ethers@^4.0.33:
+  version "4.0.33"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.33.tgz#f7b88d2419d731a39aefc37843a3f293e396f918"
+  integrity sha512-lAHkSPzBe0Vj+JrhmkEHLtUEKEheVktIjGDyE9gbzF4zf1vibjYgB57LraDHu4/ItqWVkztgsm8GWqcDMN+6vQ==
   dependencies:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"


### PR DESCRIPTION
This PR upgrades the `ethers` dev dependency to version `4.0.33`.

This was done manually because GK couldn't automatically update due to a broken build.

Resolves #240 