### PR TITLE
Adjust error handling for static methods (MetaMask/Trezor)

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -32,6 +32,75 @@ import {
 import { STD_ERRORS } from './defaults';
 import { staticMethods as messages } from './messages';
 
+export const signTransactionCallback = (
+  resolve: (string) => void,
+  reject: (Error) => void,
+) =>
+  async (error: Error, transactionHash: string) => {
+    try {
+      if (error) {
+        /*
+         * If the user cancels signing the transaction we still throw,
+         * but we customize the message.
+         */
+        if (error.message.includes(STD_ERRORS.CANCEL_TX_SIGN)) {
+          throw new Error(messages.cancelTransactionSign);
+        }
+        throw new Error(error.message);
+      }
+
+      /*
+       * Validate that the signature hash is in the correct format
+       */
+      hexSequenceValidator(transactionHash);
+      /*
+       * Add the `0x` prefix to the signed transaction hash
+       */
+      const normalizedTransactionHash: string = hexSequenceNormalizer(
+        transactionHash,
+      );
+      /*
+       * Get signed transaction object with transaction hash using Web3
+       * Include signature + any values MetaMask may have changed.
+       */
+      const {
+        gas,
+        gasPrice: signedGasPrice,
+        input: signedData,
+        nonce,
+        r,
+        s,
+        to: signedTo,
+        v,
+        value: signedValue,
+      } = await getTransactionMethodLink(normalizedTransactionHash);
+      /*
+       * RLP encode (to hex string) with ethereumjs-tx, prefix with
+       * `0x` and return. Convert to BN all the numbers-as-strings.
+       */
+      const signedTransaction = new EthereumTx({
+        data: signedData,
+        gasLimit: new BigNumber(gas),
+        gasPrice: new BigNumber(signedGasPrice),
+        nonce: new BigNumber(nonce),
+        r,
+        s,
+        to: signedTo,
+        v,
+        value: new BigNumber(signedValue),
+      });
+      const serializedSignedTransaction = signedTransaction
+        .serialize()
+        .toString(HEX_HASH_TYPE);
+      const normalizedSignedTransaction = hexSequenceNormalizer(
+        serializedSignedTransaction,
+      );
+      return resolve(normalizedSignedTransaction);
+    } catch (caughtError) {
+      return reject(caughtError);
+    }
+  };
+
 /**
  * Sign (and send) a transaction object and return the serialized signature (as a hex string)
  *
@@ -93,7 +162,7 @@ export const signTransaction = async ({
      * This way we could better test it
      */
     () =>
-      new Promise(resolve =>
+      new Promise((resolve, reject) =>
         signTransactionMethodLink(
           Object.assign(
             {},
@@ -118,74 +187,45 @@ export const signTransaction = async ({
              */
             typeof to !== 'undefined' ? { to: addressNormalizer(to) } : {},
           ),
-          /*
-           * @TODO Move into own (non-anonymous) method
-           * This way we could better test it
-           */
-          async (error: Error, transactionHash: string) => {
-            try {
-              /*
-               * Validate that the signature hash is in the correct format
-               */
-              hexSequenceValidator(transactionHash);
-              /*
-               * Add the `0x` prefix to the signed transaction hash
-               */
-              const normalizedTransactionHash: string = hexSequenceNormalizer(
-                transactionHash,
-              );
-              /*
-               * Get signed transaction object with transaction hash using Web3
-               * Include signature + any values MetaMask may have changed.
-               */
-              const {
-                gas,
-                gasPrice: signedGasPrice,
-                input: signedData,
-                nonce,
-                r,
-                s,
-                to: signedTo,
-                v,
-                value: signedValue
-              } = await getTransactionMethodLink(normalizedTransactionHash);
-              /*
-               * RLP encode (to hex string) with ethereumjs-tx, prefix with
-               * `0x` and return. Convert to BN all the numbers-as-strings.
-               */
-              const signedTransaction = new EthereumTx({
-                data: signedData,
-                gasLimit: new BigNumber(gas),
-                gasPrice: new BigNumber(signedGasPrice),
-                nonce: new BigNumber(nonce),
-                r,
-                s,
-                to: signedTo,
-                v,
-                value: new BigNumber(signedValue),
-              });
-              const serializedSignedTransaction =
-                signedTransaction.serialize().toString(HEX_HASH_TYPE);
-              const normalizedSignedTransaction = hexSequenceNormalizer(
-                serializedSignedTransaction,
-              )
-              return resolve(normalizedSignedTransaction);
-            } catch (caughtError) {
-              /*
-               * If the user cancels signing the transaction we still throw,
-               * but we customize the message
-               */
-              if (error.message.includes(STD_ERRORS.CANCEL_TX_SIGN)) {
-                throw new Error(messages.cancelTransactionSign);
-              }
-              throw new Error(error.message);
-            }
-          },
+          signTransactionCallback(resolve, reject),
         ),
       ),
     messages.cannotSendTransaction,
   );
 };
+
+export const signMessageCallback = (
+  resolve: (string | void) => void,
+  reject: (Error) => void,
+) =>
+  (error: Error, messageSignature: string) => {
+    try {
+      if (error) {
+        /*
+         * If the user cancels signing the message we still throw,
+         * but we customize the message
+         */
+        if (error.message.includes(STD_ERRORS.CANCEL_MSG_SIGN)) {
+          throw new Error(messages.cancelMessageSign);
+        }
+        throw new Error(error.message);
+      }
+
+      /*
+       * Validate that the signature is in the correct format
+       */
+      hexSequenceValidator(messageSignature);
+      /*
+       * Add the `0x` prefix to the message's signature
+       */
+      const normalizedSignature: string = hexSequenceNormalizer(
+        messageSignature,
+      );
+      return resolve(normalizedSignature);
+    } catch (caughtError) {
+      return reject(caughtError);
+    }
+  };
 
 /**
  * Sign a message and return the signature. Useful for verifying identities.
@@ -194,6 +234,7 @@ export const signTransaction = async ({
  *
  * @param {string} currentAddress The current selected address (in the UI)
  * @param {string} message the message you want to sign
+ * @param {any} messageData the message data (hex string or UInt8Array) you want to sign
  *
  * All the above params are sent in as props of an {object.
  *
@@ -202,7 +243,7 @@ export const signTransaction = async ({
 export const signMessage = async ({
   currentAddress,
   message,
-  messageData
+  messageData,
 }: Object = {}): Promise<string | void> => {
   addressValidator(currentAddress);
   const toSign = messageOrDataValidator({ message, messageData });
@@ -217,7 +258,7 @@ export const signMessage = async ({
      * This way we could better test it
      */
     () =>
-      new Promise(resolve => {
+      new Promise((resolve, reject) => {
         /*
          * Sign the message. This will prompt the user via Metamask's UI
          */
@@ -233,39 +274,47 @@ export const signMessage = async ({
             Buffer.from(toSign).toString(HEX_HASH_TYPE),
           ),
           currentAddress,
-          /*
-           * @TODO Move into own (non-anonymous) method
-           * This way we could better test it
-           */
-          (error: Error, messageSignature: string) => {
-            try {
-              /*
-               * Validate that the signature is in the correct format
-               */
-              hexSequenceValidator(messageSignature);
-              /*
-               * Add the `0x` prefix to the message's signature
-               */
-              const normalizedSignature: string = hexSequenceNormalizer(
-                messageSignature,
-              );
-              return resolve(normalizedSignature);
-            } catch (caughtError) {
-              /*
-               * If the user cancels signing the message we still throw,
-               * but we customize the message
-               */
-              if (error.message.includes(STD_ERRORS.CANCEL_MSG_SIGN)) {
-                throw new Error(messages.cancelMessageSign);
-              }
-              throw new Error(error.message);
-            }
-          },
+          signMessageCallback(resolve, reject),
         );
       }),
     messages.cannotSignMessage,
   );
 };
+
+export const verifyMessageCallback = (
+  currentAddress: string,
+  resolve: (boolean) => void,
+  reject: (Error) => void,
+) =>
+  (error: Error, recoveredAddress: string) => {
+    try {
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      /*
+       * Validate that the recovered address is correct
+       */
+      addressValidator(recoveredAddress);
+      /*
+       * Add the `0x` prefix to the recovered address
+       */
+      const normalizedRecoveredAddress: string = addressNormalizer(
+        recoveredAddress,
+      );
+      /*
+       * Add the `0x` prefix to the current address
+       */
+      const normalizedCurrentAddress: string = addressNormalizer(
+        currentAddress,
+      );
+      return resolve(
+        normalizedRecoveredAddress === normalizedCurrentAddress,
+      );
+    } catch (caughtError) {
+      return reject(caughtError);
+    }
+  };
 
 /**
  * Verify a signed message. Useful for verifying identity. (In conjunction with `signMessage`)
@@ -305,7 +354,7 @@ export const verifyMessage = async ({
      * This way we could better test it
      */
     () =>
-      new Promise(resolve => {
+      new Promise((resolve, reject) => {
         /*
          * Verify the message
          */
@@ -315,35 +364,7 @@ export const verifyMessage = async ({
            * Ensure the signature has the `0x` prefix
            */
           hexSequenceNormalizer(signature),
-          /*
-           * @TODO Move into own (non-anonymous) method
-           * This way we could better test it
-           */
-          (error: Error, recoveredAddress: string) => {
-            try {
-              /*
-               * Validate that the recovered address is correct
-               */
-              addressValidator(recoveredAddress);
-              /*
-               * Add the `0x` prefix to the recovered address
-               */
-              const normalizedRecoveredAddress: string = addressNormalizer(
-                recoveredAddress,
-              );
-              /*
-               * Add the `0x` prefix to the current address
-               */
-              const normalizedCurrentAddress: string = addressNormalizer(
-                currentAddress,
-              );
-              return resolve(
-                normalizedRecoveredAddress === normalizedCurrentAddress,
-              );
-            } catch (caughtError) {
-              throw new Error(error.message);
-            }
-          },
+          verifyMessageCallback(currentAddress, resolve, reject),
         );
       }),
     messages.cannotSignMessage,

--- a/modules/node_modules/@colony/purser-trezor/staticMethods.js
+++ b/modules/node_modules/@colony/purser-trezor/staticMethods.js
@@ -255,10 +255,11 @@ export const signTransaction = async ({
     );
   } catch (caughtError) {
     /*
-     * Don't throw an error if the user cancelled
+     * If the user cancels signing the transaction we still throw,
+     * but we customize the message.
      */
     if (caughtError.message === STD_ERRORS.CANCEL_TX_SIGN) {
-      return warning(messages.userSignTxCancel);
+      throw new Error(messages.userSignTxCancel);
     }
     /*
      * But throw otherwise, so we can see what's going on
@@ -319,10 +320,11 @@ export const signMessage = async ({
     return hexSequenceNormalizer(signedMessage);
   } catch (caughtError) {
     /*
-     * Don't throw an error if the user cancelled
+     * If the user cancels signing the message we still throw,
+     * but we customize the message
      */
     if (caughtError.message === STD_ERRORS.CANCEL_TX_SIGN) {
-      return warning(messages.userSignTxCancel);
+      throw new Error(messages.userSignTxCancel);
     }
     /*
      * But throw otherwise, so we can see what's going on

--- a/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
@@ -4,6 +4,7 @@ import { transactionObjectValidator } from '@colony/purser-core/helpers';
 import * as utils from '@colony/purser-core/utils';
 
 import { signTransaction } from '@colony/purser-trezor/staticMethods';
+import { staticMethods as messages } from '@colony/purser-trezor/messages';
 import { payloadListener } from '@colony/purser-trezor/helpers';
 import {
   derivationPathNormalizer,
@@ -170,9 +171,12 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
       payloadListener.mockImplementation(() =>
         Promise.reject(new Error('Oh no!')),
       );
-      expect(signTransaction(mockedArgumentsObject)).rejects.toThrow();
+      expect(signTransaction(mockedArgumentsObject)).rejects.toHaveProperty(
+        'message',
+        expect.stringContaining('Oh no!'),
+      );
     });
-    test('Log a warning if the user Cancels signing it', async () => {
+    test('Throws if the user cancels signing it', async () => {
       /*
        * We're re-mocking the helpers just for this test so we can simulate
        * a cancel response.
@@ -180,11 +184,10 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
       payloadListener.mockImplementation(() =>
         Promise.reject(new Error(STD_ERRORS.CANCEL_TX_SIGN)),
       );
-      await signTransaction(mockedArgumentsObject);
-      /*
-       * User cancelled, so we don't throw
-       */
-      expect(utils.warning).toHaveBeenCalled();
+      expect(signTransaction(mockedTransactionObject)).rejects.toHaveProperty(
+        'message',
+        messages.userSignTxCancel,
+      );
     });
     test('Signs a transaction without a destination address', async () => {
       expect(


### PR DESCRIPTION
This PR makes some changes to the error handling for the static methods of MetaMask/Trezor wallets, such that all errors can be caught, and error behaviour when cancelling signing is the same across wallet types.

*Trezor*
* Throw an error (rather than log a warning) when the user cancels signing a message/transaction with a Trezor wallet
* Make tests more specific for errors


*MetaMask*
* Ensure that the static methods (`signMessage`, `signTransaction`, `verifyMessage`) reject the promise when errors are encountered in their callbacks
* Define static method callbacks as separate methods
* Make tests more specific for errors
* Add missing JSDoc parameter for `signMessage`