### PR TITLE
Release v2.4.0 Minor

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/package.json
+++ b/modules/node_modules/@colony/purser-metamask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/purser-metamask",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A javascript library to interact with a Metamask based Ethereum wallet",
   "keywords": [
     "metamask",

--- a/modules/node_modules/@colony/purser-trezor/package.json
+++ b/modules/node_modules/@colony/purser-trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/purser-trezor",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "A javascript library to interact with a Trezor based Ethereum wallet",
   "keywords": [
     "trezor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purser",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Interact with Ethereum wallets easily",
   "scripts": {
     "build": "node scripts/build-all-modules.js",


### PR DESCRIPTION
This PR bumps the `monorepo` and all the modules to their respective new versions for the upcoming [`MINOR`](https://semver.org/) release:
- Monorepo: `2.4.0`
- `purser-metamask`: `2.3.1`
- `purser-trezor`: `1.3.0`