### PR TITLE
Fix `ethereumjs-tx` import

### DIFF
--- a/modules/node_modules/@colony/purser-ledger/staticMethods.js
+++ b/modules/node_modules/@colony/purser-ledger/staticMethods.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import EthereumTx from 'ethereumjs-tx';
+import { Transaction as EthereumTx } from 'ethereumjs-tx';
 
 import {
   derivationPathValidator,

--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import EthereumTx from 'ethereumjs-tx';
+import { Transaction as EthereumTx } from 'ethereumjs-tx';
 import BigNumber from 'bn.js';
 
 import { warning } from '@colony/purser-core/utils';

--- a/modules/node_modules/@colony/purser-trezor/staticMethods.js
+++ b/modules/node_modules/@colony/purser-trezor/staticMethods.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { fromString } from 'bip32-path';
-import EthereumTx from 'ethereumjs-tx';
+import { Transaction as EthereumTx } from 'ethereumjs-tx';
 
 import {
   addressValidator,

--- a/modules/tests/mocks/ethereumjs-tx.js
+++ b/modules/tests/mocks/ethereumjs-tx.js
@@ -1,7 +1,9 @@
-export const EthereumTx = jest.fn().mockImplementation(() => ({
+export const Transaction = jest.fn().mockImplementation(() => ({
   serialize: () => ({
-    toString: () => 'mocked-hex-string',
+    toString: () => 'mocked-serialized-signed-transaction',
   }),
 }));
 
-export default EthereumTx;
+const EthereumJsTx = jest.fn(() => ({ Transaction }));
+
+export default EthereumJsTx;

--- a/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
@@ -1,4 +1,4 @@
-import EthereumTx from 'ethereumjs-tx';
+import { Transaction as EthereumTx } from 'ethereumjs-tx';
 
 import { transactionObjectValidator } from '@colony/purser-core/helpers';
 import * as utils from '@colony/purser-core/utils';
@@ -68,7 +68,6 @@ const mockedArgumentsObject = {
 
 describe('`Ledger` Hardware Wallet Module Static Methods', () => {
   afterEach(() => {
-    EthereumTx.mockClear();
     derivationPathNormalizer.mockClear();
     multipleOfTwoHexValueNormalizer.mockClear();
     addressNormalizer.mockClear();

--- a/modules/tests/purser-metamask/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-metamask/staticMethods/signTransaction.test.js
@@ -1,5 +1,3 @@
-import EthereumTx from 'ethereumjs-tx';
-
 import { transactionObjectValidator } from '@colony/purser-core/helpers';
 import { warning } from '@colony/purser-core/utils';
 
@@ -20,6 +18,7 @@ import { STD_ERRORS } from '@colony/purser-metamask/defaults';
 
 jest.dontMock('@colony/purser-metamask/staticMethods');
 
+jest.mock('ethereumjs-tx');
 jest.mock('@colony/purser-core/validators');
 /*
  * @TODO Fix manual mocks
@@ -54,19 +53,6 @@ global.web3 = {
 };
 
 /*
- * Mock ethereumjs-tx serialization
- */
-const mockedSerializedSignedTransaction =
-  'mocked-serialized-signed-transaction';
-jest.mock('ethereumjs-tx', () =>
-  jest.fn().mockImplementation(() => ({
-    serialize: jest.fn().mockReturnValue({
-      toString: jest.fn().mockReturnValue(mockedSerializedSignedTransaction),
-    }),
-  })),
-);
-
-/*
  * These values are not correct. Do not use the as reference.
  * If the validators wouldn't be mocked, they wouldn't pass.
  */
@@ -93,7 +79,6 @@ describe('`Metamask` Wallet Module Static Methods', () => {
   afterEach(() => {
     global.web3.eth.sendTransaction.mockClear();
     global.web3.eth.getTransaction.mockClear();
-    EthereumTx.mockClear();
     methodCaller.mockClear();
     transactionObjectValidator.mockClear();
     addressValidator.mockClear();
@@ -200,7 +185,7 @@ describe('`Metamask` Wallet Module Static Methods', () => {
     test('Returns the valid hash received from signing', async () => {
       const signedTransaction = await signTransaction(mockedArgumentsObject);
       expect(global.web3.eth.getTransaction).toHaveBeenCalled();
-      expect(signedTransaction).toEqual(mockedSerializedSignedTransaction);
+      expect(signedTransaction).toEqual('mocked-serialized-signed-transaction');
     });
     test('Throws if something goes wrong while processing the signed transaction', async () => {
       /*

--- a/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
@@ -1,4 +1,4 @@
-import EthereumTx from 'ethereumjs-tx';
+import { Transaction as EthereumTx } from 'ethereumjs-tx';
 
 import { transactionObjectValidator } from '@colony/purser-core/helpers';
 import * as utils from '@colony/purser-core/utils';
@@ -67,7 +67,6 @@ const mockedArgumentsObject = {
 
 describe('`Trezor` Hardware Wallet Module Static Methods', () => {
   afterEach(() => {
-    EthereumTx.mockClear();
     derivationPathNormalizer.mockClear();
     multipleOfTwoHexValueNormalizer.mockClear();
     addressNormalizer.mockClear();

--- a/scripts/build-individual-module.js
+++ b/scripts/build-individual-module.js
@@ -62,7 +62,7 @@ const buildIndividualModule = async (moduleName) => {
     )}${chalk.white(' @ ')}${chalk.white.bold(
       packageFile.version
     )}`,
-  );cjsBuildFolder
+  );
   /*
    * Build ES Modules
    */


### PR DESCRIPTION
This PR makes a fix to the importing of `ethereumjs-tx`, which had a recent breaking change to its export.

**Changes**

* Fix the `ethereumjs-tx` import that was a breaking change of its `2.x` release
* Side fix: Remove a (seemingly harmless) typo in the build script