### PR TITLE
Upgrade `@ledgerhq/hw-app-eth` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@ledgerhq/hw-app-eth": "^4.19.0",
+    "@ledgerhq/hw-app-eth": "^4.68.1",
     "@ledgerhq/hw-transport-u2f": "^4.50.0",
     "bip32-path": "^0.4.2",
     "bn.js": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,16 +772,32 @@
   dependencies:
     "@ledgerhq/errors" "^4.50.0"
 
+"@ledgerhq/devices@^4.68.0":
+  version "4.68.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.68.0.tgz#bc674a6b00261ab916b1a34c4f2b5a62f0c94107"
+  integrity sha512-qVTy3YNDjBpg9oJGJxl00ZGPJLBCw+2PHHHLZw/xK57sPKRAdHJ+KTAxS707hRdNaT4xhLiTQuCHpPfIsYVDcQ==
+  dependencies:
+    "@ledgerhq/errors" "^4.68.0"
+    "@ledgerhq/logs" "^4.64.0"
+    rxjs "^6.5.2"
+
 "@ledgerhq/errors@^4.50.0":
   version "4.50.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.50.0.tgz#d330e396d47bbbe474fe0adfa087eeb7edd76912"
   integrity sha512-Xg5GTDUWprVJ5zCWtfESLfI1qyr09JQH8pLtWDCkz3GxlwnFPtMAvKB9qUoc2Ou4zJ9DfsZdS8KaZ/2VKXkYGA==
 
-"@ledgerhq/hw-app-eth@^4.19.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.24.0.tgz#b62514e0d18672d6d35d76dfbeaf93b67d2e5324"
+"@ledgerhq/errors@^4.68.0":
+  version "4.68.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.68.0.tgz#311980a3e2b3d43b2f7381cb6b122f5a57e2539b"
+  integrity sha512-C+VjnCili9OgT4xaCpn0CYH+ri6BaJ4If7fFb5cXEj5WrahXBOLx6+tOWLaVXUIbBBaK+ia62+eSLecV2VMCqw==
+
+"@ledgerhq/hw-app-eth@^4.68.1":
+  version "4.68.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.68.1.tgz#ba99a3d0655cc3c5efdb00002ddbdf6ba62b3a40"
+  integrity sha512-Vq0QMgZndjnf3zc6312tiX32Ktw0ddaL7d0P9S1XpP1Swx7EdjMYbxbGSdFD4iHiZ/ZVhfJNq1T7wEQ3K23RNA==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.24.0"
+    "@ledgerhq/errors" "^4.68.0"
+    "@ledgerhq/hw-transport" "^4.68.0"
 
 "@ledgerhq/hw-transport-u2f@^4.50.0":
   version "4.50.0"
@@ -792,12 +808,6 @@
     "@ledgerhq/hw-transport" "^4.50.0"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport@^4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.24.0.tgz#8def925d8c2e1f73d15128d9e27ead729870be58"
-  dependencies:
-    events "^3.0.0"
-
 "@ledgerhq/hw-transport@^4.50.0":
   version "4.50.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.50.0.tgz#2b4c8e9954a9fe7e616cb936ae105fa1de776095"
@@ -806,6 +816,20 @@
     "@ledgerhq/devices" "^4.50.0"
     "@ledgerhq/errors" "^4.50.0"
     events "^3.0.0"
+
+"@ledgerhq/hw-transport@^4.68.0":
+  version "4.68.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.68.0.tgz#47a2f2de6bb4ad7003a4da1f2f61730bb86f2f28"
+  integrity sha512-+zvy8uI/4hB1lIjN/GBseCHG1hLDzySuJpcI4V4Zy5TPP8D/igw1F56nha5A8fRvzCCPl1zPQvTwg6Fj9lKdSw==
+  dependencies:
+    "@ledgerhq/devices" "^4.68.0"
+    "@ledgerhq/errors" "^4.68.0"
+    events "^3.0.0"
+
+"@ledgerhq/logs@^4.64.0":
+  version "4.64.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.64.0.tgz#19a335e3f2d9188188437f8dabb06e0fd45b0052"
+  integrity sha512-NwgA7q1CXWMkqxoHVaSTk0gJUGbiBbWTM7Uod/Zz8EWNa1Ns0yHthCcSS279htP6oQplEaSppzsie5bcbwNApg==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -6015,6 +6039,13 @@ rxjs@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This PR manually updates the `@ledgerhq/hw-app-eth` dependency package to version `4.68.1` manually, due to some initial build failing on CI when greenkeeper attempted to do this automatically.

Resolves #255 