### PR TITLE
Release v2.5.0 Minor

### DIFF
--- a/modules/node_modules/@colony/purser-core/package.json
+++ b/modules/node_modules/@colony/purser-core/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@colony/purser-core",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A collection of helpers, utils, validators and normalizers to assist the individual purser modules"
 }

--- a/modules/node_modules/@colony/purser-ledger/package.json
+++ b/modules/node_modules/@colony/purser-ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/purser-ledger",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "A javascript library to interact with a Ledger based ethereum wallet",
   "keywords": [
     "ledger",

--- a/modules/node_modules/@colony/purser-metamask/package.json
+++ b/modules/node_modules/@colony/purser-metamask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/purser-metamask",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "A javascript library to interact with a Metamask based Ethereum wallet",
   "keywords": [
     "metamask",

--- a/modules/node_modules/@colony/purser-trezor/package.json
+++ b/modules/node_modules/@colony/purser-trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/purser-trezor",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "A javascript library to interact with a Trezor based Ethereum wallet",
   "keywords": [
     "trezor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purser",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Interact with Ethereum wallets easily",
   "scripts": {
     "build": "node scripts/build-all-modules.js",


### PR DESCRIPTION
This PR bumps the `monorepo` and all the modules to their respective new versions for the upcoming [`MINOR`](https://semver.org/) release:

- Monorepo: `2.5.0`
- `purser-core`: `2.2.0`
- `purser-ledger`: `1.4.0`
- `purser-metamask`: `2.4.0`
- `purser-trezor`: `1.4.0`