### PR TITLE
Add MetaMask/Infura workaround for pending transactions

### DIFF
--- a/modules/node_modules/@colony/purser-core/defaults.js
+++ b/modules/node_modules/@colony/purser-core/defaults.js
@@ -122,11 +122,39 @@ export const HTTPS_PROTOCOL: string = 'https:';
 /*
  * Chain IDs
  */
-export const NETWORK_IDS: Object = {
+export const CHAIN_IDS: Object = {
   HOMESTEAD: 1,
   ROPSTEN: 3,
   RINKEBY: 4,
+  GOERLI: 5,
   KOVAN: 42,
+  LOCAL: 1337,
+};
+
+/*
+ * Network names
+ */
+export const NETWORK_NAMES: Object = {
+  MAINNET: 'mainnet',
+  ROPSTEN: 'ropsten',
+  RINKEBY: 'rinkeby',
+  KOVAN: 'kovan',
+  GOERLI: 'goerli',
+};
+
+/*
+ * Hardforks
+ */
+export const HARDFORKS: Object = {
+  BYZANTIUM: 'byzantium',
+  CHAINSTART: 'chainstart',
+  CONSTANTINOPLE: 'constantinople',
+  DAO: 'dao',
+  HOMESTEAD: 'homestead',
+  ISTANBUL: 'istanbul',
+  PETERSBURG: 'petersburg',
+  SPURIOUS_DRAGON: 'spuriousDragon',
+  TANGERINE_WHISTLE: 'tangerineWhistle',
 };
 
 /*

--- a/modules/node_modules/@colony/purser-core/genericWallet.js
+++ b/modules/node_modules/@colony/purser-core/genericWallet.js
@@ -11,7 +11,7 @@ import {
 import { addressNormalizer, hexSequenceNormalizer } from './normalizers';
 
 import { genericClass as messages } from './messages';
-import { HEX_HASH_TYPE, DESCRIPTORS, SPLITTER, NETWORK_IDS } from './defaults';
+import { HEX_HASH_TYPE, DESCRIPTORS, SPLITTER, CHAIN_IDS } from './defaults';
 import { TYPE_GENERIC, SUBTYPE_GENERIC } from './types';
 
 import type { GenericClassArgumentsType } from './flowtypes';
@@ -70,7 +70,7 @@ export default class GenericWallet {
     chainCode,
     rootDerivationPath,
     addressCount = 10,
-    chainId = NETWORK_IDS.HOMESTEAD,
+    chainId = CHAIN_IDS.HOMESTEAD,
   }: GenericClassArgumentsType) {
     /*
      * Validate address count (this comes from the end user)

--- a/modules/node_modules/@colony/purser-core/helpers.js
+++ b/modules/node_modules/@colony/purser-core/helpers.js
@@ -15,7 +15,14 @@ import { hexSequenceNormalizer, recoveryParamNormalizer } from './normalizers';
 import { bigNumber, warning } from './utils';
 
 import { helpers as helperMessages } from './messages';
-import { PATH, TRANSACTION, HEX_HASH_TYPE } from './defaults';
+import {
+  CHAIN_IDS,
+  HARDFORKS,
+  HEX_HASH_TYPE,
+  NETWORK_NAMES,
+  PATH,
+  TRANSACTION,
+} from './defaults';
 
 import type {
   DerivationPathObjectType,
@@ -435,14 +442,21 @@ export const getChainDefinition = (chainId: number): {| common: Object |} => {
        *
        * @TODO Provide a means to specify all chain properties for transactions
        */
-      case 1:
-      case 1337:
-        return 'mainnet';
-      case 5:
-        return 'goerli';
+      case CHAIN_IDS.HOMESTEAD:
+      case CHAIN_IDS.LOCAL:
+        return NETWORK_NAMES.MAINNET;
+      case CHAIN_IDS.GOERLI:
+        return NETWORK_NAMES.GOERLI;
       /*
-       * Other chain IDs _may_ cause validation errors in `ethereumjs-common`
+       * The following (or other) chain IDs _may_ cause validation errors
+       * in `ethereumjs-common`
        */
+      case CHAIN_IDS.KOVAN:
+        return NETWORK_NAMES.KOVAN;
+      case CHAIN_IDS.ROPSTEN:
+        return NETWORK_NAMES.ROPSTEN;
+      case CHAIN_IDS.RINKEBY:
+        return NETWORK_NAMES.RINKEBY;
       default:
         return chainId;
     }
@@ -456,7 +470,7 @@ export const getChainDefinition = (chainId: number): {| common: Object |} => {
        * using the current default for this property. This is also an
        * assumption, and this should be made configurable.
        */
-      'petersburg',
+      HARDFORKS.PETERSBURG,
     ),
   };
 };

--- a/modules/node_modules/@colony/purser-ledger/index.js
+++ b/modules/node_modules/@colony/purser-ledger/index.js
@@ -4,7 +4,7 @@ import {
   derivationPathSerializer,
   userInputValidator,
 } from '@colony/purser-core/helpers';
-import { PATH, NETWORK_IDS } from '@colony/purser-core/defaults';
+import { PATH, CHAIN_IDS } from '@colony/purser-core/defaults';
 
 import type { WalletArgumentsType } from '@colony/purser-core/flowtypes';
 
@@ -38,7 +38,7 @@ export const open = async (
   userInputValidator({
     firstArgument: argumentObject,
   });
-  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  const { addressCount, chainId = CHAIN_IDS.HOMESTEAD } = argumentObject;
   /*
    * @TODO Reduce code repetition
    * By moving this inside a helper. This same patter will be used on the
@@ -48,7 +48,7 @@ export const open = async (
    * This will be used in the derivation path
    */
   const coinType: number =
-    chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
+    chainId === CHAIN_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
   /*
    * Get to root derivation path based on the coin type.
    *

--- a/modules/node_modules/@colony/purser-metamask/staticMethods.js
+++ b/modules/node_modules/@colony/purser-metamask/staticMethods.js
@@ -2,6 +2,7 @@
 
 import { Transaction as EthereumTx } from 'ethereumjs-tx';
 import BigNumber from 'bn.js';
+import { awaitTx } from 'await-transaction-mined';
 
 import { warning } from '@colony/purser-core/utils';
 import {
@@ -32,6 +33,41 @@ import {
 
 import { STD_ERRORS } from './defaults';
 import { staticMethods as messages } from './messages';
+
+import type { Web3TransactionType } from './flowtypes';
+
+/**
+ * Get a transaction, with a workaround for some providers not returning
+ * a pending transaction.
+ *
+ * If the transaction was not immediately returned, it's possible that
+ * Infura is being used, and it isn't responding to `eth_getTransaction`
+ * in the expected way (i.e. it isn't returning anything because the
+ * transaction is not yet confirmed).
+ *
+ * This method uses a web3 0.20.x-compatible means of waiting for the
+ * transaction to be confirmed (which will resolve to the receipt,
+ * or reject if the transaction could not be confirmed.
+ *
+ * This can probably be removed when MetaMask has its own workaround.
+ * See https://github.com/MetaMask/metamask-extension/issues/6704
+ */
+export const getTransaction = async (
+  transactionHash: string,
+): Promise<Web3TransactionType> => {
+  const receiptPromise = awaitTx(global.web3, transactionHash, {
+    blocksToWait: 1,
+  });
+
+  const transaction = await getTransactionMethodLink(transactionHash);
+  if (transaction) {
+    return transaction;
+  }
+
+  await receiptPromise;
+
+  return getTransactionMethodLink(transactionHash);
+};
 
 export const signTransactionCallback = (
   chainId: number,
@@ -75,7 +111,7 @@ export const signTransactionCallback = (
         to: signedTo,
         v,
         value: signedValue,
-      } = await getTransactionMethodLink(normalizedTransactionHash);
+      } = await getTransaction(normalizedTransactionHash);
       /*
        * RLP encode (to hex string) with ethereumjs-tx, prefix with
        * `0x` and return. Convert to BN all the numbers-as-strings.

--- a/modules/node_modules/@colony/purser-software/index.js
+++ b/modules/node_modules/@colony/purser-software/index.js
@@ -14,7 +14,7 @@ import {
   warning,
 } from '@colony/purser-core/utils';
 
-import { PATH, NETWORK_IDS } from '@colony/purser-core/defaults';
+import { PATH, CHAIN_IDS } from '@colony/purser-core/defaults';
 
 import type {
   WalletObjectType,
@@ -68,7 +68,7 @@ export const open = async (
     privateKey,
     mnemonic,
     keystore,
-    chainId = NETWORK_IDS.HOMESTEAD,
+    chainId = CHAIN_IDS.HOMESTEAD,
   } = argumentObject;
   let extractedPrivateKey: string;
   /*
@@ -184,7 +184,7 @@ export const create = async (
   const {
     password,
     entropy = getRandomValues(new Uint8Array(65536)),
-    chainId = NETWORK_IDS.HOMESTEAD,
+    chainId = CHAIN_IDS.HOMESTEAD,
   } = argumentObject;
   let basicWallet: WalletObjectType;
   try {

--- a/modules/node_modules/@colony/purser-trezor/index.js
+++ b/modules/node_modules/@colony/purser-trezor/index.js
@@ -8,7 +8,7 @@ import {
 } from '@colony/purser-core/helpers';
 import { warning, objectToErrorString } from '@colony/purser-core/utils';
 
-import { PATH, NETWORK_IDS } from '@colony/purser-core/defaults';
+import { PATH, CHAIN_IDS } from '@colony/purser-core/defaults';
 import type { WalletArgumentsType } from '@colony/purser-core/flowtypes';
 
 import TrezorWallet from './class';
@@ -43,7 +43,7 @@ export const open = async (
   userInputValidator({
     firstArgument: argumentObject,
   });
-  const { addressCount, chainId = NETWORK_IDS.HOMESTEAD } = argumentObject;
+  const { addressCount, chainId = CHAIN_IDS.HOMESTEAD } = argumentObject;
   /*
    * @TODO Reduce code repetition
    * By moving this inside a helper. This same patter will be used on the
@@ -53,7 +53,7 @@ export const open = async (
    * This will be used in the derivation path
    */
   const coinType: number =
-    chainId === NETWORK_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
+    chainId === CHAIN_IDS.HOMESTEAD ? PATH.COIN_MAINNET : PATH.COIN_TESTNET;
   /*
    * Get to root derivation path based on the coin type.
    *

--- a/modules/tests/purser-core/genericWallet.test.js
+++ b/modules/tests/purser-core/genericWallet.test.js
@@ -11,7 +11,7 @@ import {
   addressNormalizer,
   hexSequenceNormalizer,
 } from '@colony/purser-core/normalizers';
-import { NETWORK_IDS } from '@colony/purser-core/defaults';
+import { CHAIN_IDS } from '@colony/purser-core/defaults';
 
 jest.dontMock('@colony/purser-core/genericWallet');
 
@@ -146,7 +146,7 @@ describe('`Core` Module', () => {
       /*
        * Address
        */
-      expect(genericWallet).toHaveProperty('chainId', NETWORK_IDS.HOMESTEAD);
+      expect(genericWallet).toHaveProperty('chainId', CHAIN_IDS.HOMESTEAD);
     });
     test('Validates values used to instantiate', async () => {
       /* eslint-disable-next-line no-new */

--- a/modules/tests/purser-ledger/open.test.js
+++ b/modules/tests/purser-ledger/open.test.js
@@ -2,7 +2,7 @@ import {
   derivationPathSerializer,
   userInputValidator,
 } from '@colony/purser-core/helpers';
-import { PATH, NETWORK_IDS } from '@colony/purser-core/defaults';
+import { PATH, CHAIN_IDS } from '@colony/purser-core/defaults';
 import * as utils from '@colony/purser-core/utils';
 
 import {
@@ -78,7 +78,7 @@ describe('Ledger` Hardware Wallet Module', () => {
       );
     });
     test('Sets the derivation path coin to the mainnet type', async () => {
-      await ledgerWallet.open({ chainId: NETWORK_IDS.HOMESTEAD });
+      await ledgerWallet.open({ chainId: CHAIN_IDS.HOMESTEAD });
       /*
        * Should set the coin to the mainnet 60 type
        */

--- a/modules/tests/purser-trezor/open.test.js
+++ b/modules/tests/purser-trezor/open.test.js
@@ -4,7 +4,7 @@ import {
   derivationPathSerializer,
   userInputValidator,
 } from '@colony/purser-core/helpers';
-import { PATH, NETWORK_IDS } from '@colony/purser-core/defaults';
+import { PATH, CHAIN_IDS } from '@colony/purser-core/defaults';
 
 import * as utils from '@colony/purser-core/utils';
 
@@ -94,7 +94,7 @@ describe('Trezor` Hardware Wallet Module', () => {
       );
     });
     test('Sets the derivation path coin to the mainnet type', async () => {
-      await trezorWallet.open({ chainId: NETWORK_IDS.HOMESTEAD });
+      await trezorWallet.open({ chainId: CHAIN_IDS.HOMESTEAD });
       /*
        * Should set the coin to the mainnet 60 type
        */

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@babel/runtime": "^7.1.2",
     "@ledgerhq/hw-app-eth": "^4.68.1",
     "@ledgerhq/hw-transport-u2f": "^4.68.0",
+    "await-transaction-mined": "^1.0.12",
     "bip32-path": "^0.4.2",
     "bn.js": "^5.0.0",
     "ethereumjs-common": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,6 +1085,11 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
+await-transaction-mined@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/await-transaction-mined/-/await-transaction-mined-1.0.12.tgz#be7b3eed6ce01e5b28f6e0588d38e70eaf2c81f8"
+  integrity sha512-UZ84Bh0TUVnXa/ioleGutsFP1/k6WGVWuZP2W1uWCbrcH6KwQmu3ZSq0gvKibsNrG7RSB+0UxnjDvzT2otkpoQ==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
This PR adds a workaround for an Infura issue (that becomes a problem with our MetaMask implementation) as documented [here](https://github.com/MetaMask/metamask-extension/issues/6704) and more specifically [here](https://github.com/ethers-io/ethers.js/issues/544#issuecomment-509663055). 

The crux of our issue is that `purser-metamask`'s `signTransaction` method attempts to get the transaction that MetaMask sent in the callback of `sendTransaction`, when it is pending. With most providers, the `getTransaction` method will respond with the transaction when it is pending, but Infura recently started returning an empty response.

The workaround involves attempting to get the transaction immediately, and if that fails, using a `web3` 0.20.x-compatible package (`await-transaction-mined`) to wait for the transaction to be confirmed before getting the transaction.

This PR also makes some improvements to various defaults as suggested in #261 .

* Update chain defaults
  * Add `HARDFORKS` defaults constant
  * Add `NETWORK_NAMES` defaults constant
  * Add tentative support for more chains for `getChainDefinition`
  * Rename `NETWORK_IDS` defaults constant to `CHAIN_IDS`
  * Use hardfork and network name constants `getChainDefinition`

* Add MetaMask/Infura workaround
  * Add `await-transaction-mined` dependency
  * Define a method to get a pending MetaMask transaction and if necessary (given e.g. an Infura provider), wait for the transaction to be confirmed before getting it (otherwise, the provider will return null)
