### PR TITLE
Fix Ledger/Trezor transaction signing

### DIFF
--- a/modules/node_modules/@colony/purser-core/defaults.js
+++ b/modules/node_modules/@colony/purser-core/defaults.js
@@ -113,9 +113,11 @@ export const TRANSACTION: Object = {
 export const SIGNATURE: Object = {
   R: 0,
   S: 0,
-  RECOVERY_ODD: 27,
-  RECOVERY_EVEN: 28,
+  V: 1,
 };
+
+export const RECOVERY_ODD = 27;
+export const RECOVERY_EVEN = 28;
 
 export const HTTPS_PROTOCOL: string = 'https:';
 

--- a/modules/node_modules/@colony/purser-core/normalizers.js
+++ b/modules/node_modules/@colony/purser-core/normalizers.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import BN from 'bn.js';
 import { PATH, SPLITTER, MATCH, SIGNATURE } from './defaults';
 
 /**
@@ -123,6 +124,22 @@ export const hexSequenceNormalizer = (
   hexString: string,
   prefix: boolean = true,
 ) => stringPrefixNormalizer(MATCH.HEX_STRING, hexString.toLowerCase(), prefix);
+
+/**
+ * Transform a BigNumber into a normalized hex string.
+ *
+ * @method bigNumberToHexString
+ *
+ * @param {BN} n The BigNumber to normalize
+ * @param {boolean} prefix Should the final value have a prefix?
+ *
+ * @return {string} The normalized hex string
+ */
+export const bigNumberToHexString = (n: BN, prefix: boolean = true): string =>
+  hexSequenceNormalizer(
+    multipleOfTwoHexValueNormalizer(n.toString(16)),
+    prefix,
+  );
 
 /**
  * Normalize the recovery param of an Ethereum ECDSA signature.

--- a/modules/node_modules/@colony/purser-core/utils.js
+++ b/modules/node_modules/@colony/purser-core/utils.js
@@ -53,7 +53,7 @@ export const warning = (...args: Array<*>): void => {
   let level: string = 'low';
   const lastArgIndex: number = args.length - 1;
   const options: * = args[lastArgIndex];
-  const [message]: [string] = args;
+  const [message] = args;
   const literalTemplates: Array<*> = args.slice(1);
   /*
    * We're being very specific with object testing here, since we don't want to

--- a/modules/node_modules/@colony/purser-ledger/staticMethods.js
+++ b/modules/node_modules/@colony/purser-ledger/staticMethods.js
@@ -8,7 +8,7 @@ import {
 } from '@colony/purser-core/validators';
 import {
   derivationPathNormalizer,
-  multipleOfTwoHexValueNormalizer,
+  bigNumberToHexString,
   hexSequenceNormalizer,
   addressNormalizer,
 } from '@colony/purser-core/normalizers';
@@ -20,7 +20,7 @@ import {
   messageOrDataValidator,
   getChainDefinition,
 } from '@colony/purser-core/helpers';
-import { HEX_HASH_TYPE, SIGNATURE } from '@colony/purser-core/defaults';
+import { HEX_HASH_TYPE } from '@colony/purser-core/defaults';
 import { ledgerConnection, handleLedgerConnectionError } from './helpers';
 
 import { staticMethods as messages } from './messages';
@@ -78,77 +78,11 @@ export const signTransaction = async ({
       Object.assign(
         {},
         {
-          /*
-           * We could really do with some BN.js flow types declarations :(
-           */
-          gasPrice: hexSequenceNormalizer(
-            /*
-             * @TODO Add `bigNumber` `toHexString` wrapper method
-             *
-             * Flow confuses bigNumber's `toString` with the String object
-             * prototype `toString` method
-             */
-            /* $FlowFixMe */
-            multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
-          ),
-          gasLimit: hexSequenceNormalizer(
-            /*
-             * @TODO Add `bigNumber` `toHexString` wrapper method
-             *
-             * Flow confuses bigNumber's `toString` with the String object
-             * prototype `toString` method
-             */
-            /* $FlowFixMe */
-            multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
-          ),
-          /*
-           * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
-           * Eg: '3' to be '03', `12c` to be `012c`
-           */
-          nonce: hexSequenceNormalizer(
-            /*
-             * @TODO Add `bigNumber` `toHexString` wrapper method
-             *
-             * Flow confuses bigNumber's `toString` with the String object
-             * prototype `toString` method
-             */
-            /* $FlowFixMe */
-            multipleOfTwoHexValueNormalizer(nonce.toString(16)),
-          ),
-          value: hexSequenceNormalizer(
-            /*
-             * @TODO Add `bigNumber` `toHexString` wrapper method
-             *
-             * Flow confuses bigNumber's `toString` with the String object
-             * prototype `toString` method
-             */
-            /* $FlowFixMe */
-            multipleOfTwoHexValueNormalizer(value.toString(16)),
-          ),
+          gasPrice: bigNumberToHexString(gasPrice),
+          gasLimit: bigNumberToHexString(gasLimit),
+          nonce: bigNumberToHexString(nonce),
+          value: bigNumberToHexString(value),
           data: hexSequenceNormalizer(inputData),
-          /*
-           * The transaction object needs to be seeded with the (R) and (S) signature components with
-           * empty data, and the Reco(V)ery param as the chain id (all, im hex string format).
-           *
-           * See this issue for context:
-           * https://github.com/LedgerHQ/ledgerjs/issues/43
-           */
-          r: hexSequenceNormalizer(
-            multipleOfTwoHexValueNormalizer(String(SIGNATURE.R)),
-          ),
-          s: hexSequenceNormalizer(
-            multipleOfTwoHexValueNormalizer(String(SIGNATURE.S)),
-          ),
-          v: hexSequenceNormalizer(
-            /*
-             * @TODO Add `bigNumber` `toHexString` wrapper method
-             *
-             * Flow confuses bigNumber's `toString` with the String object
-             * prototype `toString` method
-             */
-            /* $FlowFixMe */
-            multipleOfTwoHexValueNormalizer(chainId.toString(16)),
-          ),
         },
         to ? { to: addressNormalizer(to) } : {},
       ),

--- a/modules/node_modules/@colony/purser-trezor/staticMethods.js
+++ b/modules/node_modules/@colony/purser-trezor/staticMethods.js
@@ -9,7 +9,7 @@ import {
 } from '@colony/purser-core/validators';
 import {
   derivationPathNormalizer,
-  multipleOfTwoHexValueNormalizer,
+  bigNumberToHexString,
   addressNormalizer,
   hexSequenceNormalizer,
 } from '@colony/purser-core/normalizers';
@@ -25,7 +25,7 @@ import {
   getChainDefinition,
 } from '@colony/purser-core/helpers';
 
-import { HEX_HASH_TYPE, SIGNATURE } from '@colony/purser-core/defaults';
+import { HEX_HASH_TYPE } from '@colony/purser-core/defaults';
 
 import { payloadListener } from './helpers';
 
@@ -73,77 +73,11 @@ export const signTransaction = async ({
    */
   const unsignedTransaction = new EthereumTx(
     {
-      /*
-       * We could really do with some BN.js flow types declarations :(
-       */
-      gasPrice: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
-      ),
-      gasLimit: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
-      ),
-      /*
-       * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
-       * Eg: '3' to be '03', `12c` to be `012c`
-       */
-      nonce: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(nonce.toString(16)),
-      ),
-      value: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(value.toString(16)),
-      ),
+      gasPrice: bigNumberToHexString(gasPrice),
+      gasLimit: bigNumberToHexString(gasLimit),
+      nonce: bigNumberToHexString(nonce),
+      value: bigNumberToHexString(value),
       data: hexSequenceNormalizer(inputData),
-      /*
-       * The transaction object needs to be seeded with the (R) and (S) signature components with
-       * empty data, and the Reco(V)ery param as the chain id (all, im hex string format).
-       *
-       * See this issue for context:
-       * https://github.com/LedgerHQ/ledgerjs/issues/43
-       */
-      r: hexSequenceNormalizer(
-        multipleOfTwoHexValueNormalizer(String(SIGNATURE.R)),
-      ),
-      s: hexSequenceNormalizer(
-        multipleOfTwoHexValueNormalizer(String(SIGNATURE.S)),
-      ),
-      v: hexSequenceNormalizer(
-        /*
-         * @TODO Add `bigNumber` `toHexString` wrapper method
-         *
-         * Flow confuses bigNumber's `toString` with the String object
-         * prototype `toString` method
-         */
-        /* $FlowFixMe */
-        multipleOfTwoHexValueNormalizer(chainId.toString(16)),
-      ),
     },
     getChainDefinition(chainId),
   );
@@ -161,42 +95,11 @@ export const signTransaction = async ({
         derivationPathNormalizer(derivationPath),
         true,
       ).toPathArray(),
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      gas_price: multipleOfTwoHexValueNormalizer(gasPrice.toString(16)),
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      gas_limit: multipleOfTwoHexValueNormalizer(gasLimit.toString(16)),
+      gas_price: bigNumberToHexString(gasPrice, false),
+      gas_limit: bigNumberToHexString(gasLimit, false),
       chain_id: chainId,
-      /*
-       * Nonces needs to be sent in as a hex string, and to be padded as a multiple of two.
-       * Eg: '3' to be '03', `12c` to be `012c`
-       *
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      nonce: multipleOfTwoHexValueNormalizer(nonce.toString(16)),
-      /*
-       * @TODO Add `bigNumber` `toHexString` wrapper method
-       *
-       * Flow confuses bigNumber's `toString` with the String object
-       * prototype `toString` method
-       */
-      /* $FlowFixMe */
-      value: multipleOfTwoHexValueNormalizer(value.toString(16)),
+      nonce: bigNumberToHexString(nonce, false),
+      value: bigNumberToHexString(value, false),
       /*
        * Trezor service requires the prefix from the input data to be stripped
        */

--- a/modules/tests/mocks/@colony/purser-core/normalizers.js
+++ b/modules/tests/mocks/@colony/purser-core/normalizers.js
@@ -12,4 +12,6 @@ export const addressNormalizer = jest.fn(value => value);
 
 export const hexSequenceNormalizer = jest.fn(value => value);
 
+export const bigNumberToHexString = jest.fn(value => value);
+
 export const recoveryParamNormalizer = jest.fn(value => value);

--- a/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-ledger/staticMethods/signTransaction.test.js
@@ -13,13 +13,11 @@ import {
 } from '@colony/purser-ledger/helpers';
 import {
   derivationPathNormalizer,
-  multipleOfTwoHexValueNormalizer,
+  bigNumberToHexString,
   addressNormalizer,
   hexSequenceNormalizer,
 } from '@colony/purser-core/normalizers';
 import { derivationPathValidator } from '@colony/purser-core/validators';
-
-import { SIGNATURE } from '@colony/purser-core/defaults';
 
 jest.dontMock('@colony/purser-ledger/staticMethods');
 
@@ -72,7 +70,7 @@ const mockedArgumentsObject = {
 describe('`Ledger` Hardware Wallet Module Static Methods', () => {
   afterEach(() => {
     derivationPathNormalizer.mockClear();
-    multipleOfTwoHexValueNormalizer.mockClear();
+    bigNumberToHexString.mockClear();
     addressNormalizer.mockClear();
     hexSequenceNormalizer.mockClear();
     ledgerConnection.mockClear();
@@ -132,38 +130,22 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
       /*
        * Normalizes gas price and gas limit
        */
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(gasPrice);
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(gasPrice);
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(gasLimit);
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(gasLimit);
+      expect(bigNumberToHexString).toHaveBeenCalled();
+      expect(bigNumberToHexString).toHaveBeenCalledWith(gasPrice);
+      expect(bigNumberToHexString).toHaveBeenCalledWith(gasLimit);
       /*
        * Normalizes the nonce
        */
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(nonce);
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(nonce);
+      expect(bigNumberToHexString).toHaveBeenCalledWith(nonce);
       /*
        * Normalizes the transaction value
        */
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(value);
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(value);
+      expect(bigNumberToHexString).toHaveBeenCalledWith(value);
       /*
        * Normalizes the transaction input data
        */
       expect(hexSequenceNormalizer).toHaveBeenCalled();
       expect(hexSequenceNormalizer).toHaveBeenCalledWith(inputData);
-      /*
-       * Normalizes the seeded R,S and V signature components
-       */
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(String(SIGNATURE.R));
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(
-        String(SIGNATURE.R),
-      );
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(String(SIGNATURE.S));
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(
-        String(SIGNATURE.S),
-      );
-      expect(hexSequenceNormalizer).toHaveBeenCalledWith(chainId);
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(chainId);
     });
     test('Warns the user to check/confirm the device', async () => {
       await signTransaction(mockedArgumentsObject);
@@ -175,7 +157,7 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
     test('Creates the unsigned transaction object', async () => {
       await signTransaction(mockedArgumentsObject);
       /*
-       * Creates the unsigned transaction, seeding the R,S and V components
+       * Creates the unsigned transaction
        */
       expect(EthereumTx).toHaveBeenCalled();
       expect(EthereumTx).toHaveBeenCalledWith(
@@ -185,9 +167,7 @@ describe('`Ledger` Hardware Wallet Module Static Methods', () => {
           nonce,
           value,
           data: inputData,
-          r: String(SIGNATURE.R),
-          s: String(SIGNATURE.S),
-          v: chainId,
+          to,
         }),
         expect.objectContaining({ common: { chainId: 'mocked-chain-id' } }),
       );

--- a/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-trezor/staticMethods/signTransaction.test.js
@@ -11,7 +11,7 @@ import { staticMethods as messages } from '@colony/purser-trezor/messages';
 import { payloadListener } from '@colony/purser-trezor/helpers';
 import {
   derivationPathNormalizer,
-  multipleOfTwoHexValueNormalizer,
+  bigNumberToHexString,
   addressNormalizer,
   hexSequenceNormalizer,
 } from '@colony/purser-core/normalizers';
@@ -71,7 +71,7 @@ const mockedArgumentsObject = {
 describe('`Trezor` Hardware Wallet Module Static Methods', () => {
   afterEach(() => {
     derivationPathNormalizer.mockClear();
-    multipleOfTwoHexValueNormalizer.mockClear();
+    bigNumberToHexString.mockClear();
     addressNormalizer.mockClear();
     hexSequenceNormalizer.mockClear();
     getChainDefinition.mockClear();
@@ -90,9 +90,6 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
           nonce,
           value,
           data: inputData,
-          r: '0',
-          s: '0',
-          v: chainId,
         },
         { common: { chainId: 'mocked-chain-id' } },
       );
@@ -153,14 +150,14 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
       /*
        * Normalizes gas price and gas limit
        */
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalled();
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(gasPrice);
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(gasLimit);
+      expect(bigNumberToHexString).toHaveBeenCalled();
+      expect(bigNumberToHexString).toHaveBeenCalledWith(gasPrice);
+      expect(bigNumberToHexString).toHaveBeenCalledWith(gasLimit);
       /*
        * Normalizes the nonce
        */
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalled();
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(nonce);
+      expect(bigNumberToHexString).toHaveBeenCalled();
+      expect(bigNumberToHexString).toHaveBeenCalledWith(nonce);
       /*
        * Normalizes the destination address
        */
@@ -169,8 +166,8 @@ describe('`Trezor` Hardware Wallet Module Static Methods', () => {
       /*
        * Normalizes the transaction value
        */
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalled();
-      expect(multipleOfTwoHexValueNormalizer).toHaveBeenCalledWith(value);
+      expect(bigNumberToHexString).toHaveBeenCalled();
+      expect(bigNumberToHexString).toHaveBeenCalledWith(value);
       /*
        * Normalizes the transaction input data
        */

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@ledgerhq/hw-app-eth": "^4.68.1",
-    "@ledgerhq/hw-transport-u2f": "^4.68.0",
+    "@ledgerhq/hw-app-eth": "^4.68.2",
+    "@ledgerhq/hw-transport-u2f": "^4.68.2",
     "await-transaction-mined": "^1.0.12",
     "bip32-path": "^0.4.2",
     "bn.js": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,51 +765,51 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@kironeducation/flow-junit-transformer/-/flow-junit-transformer-0.3.0.tgz#ea1e57b01d7096012254a3d3dafc8afc7d97b8fe"
 
-"@ledgerhq/devices@^4.68.0":
-  version "4.68.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.68.0.tgz#bc674a6b00261ab916b1a34c4f2b5a62f0c94107"
-  integrity sha512-qVTy3YNDjBpg9oJGJxl00ZGPJLBCw+2PHHHLZw/xK57sPKRAdHJ+KTAxS707hRdNaT4xhLiTQuCHpPfIsYVDcQ==
+"@ledgerhq/devices@^4.68.2":
+  version "4.68.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.68.2.tgz#73206d526ec3cd34eec49eddb31d8c0086bde518"
+  integrity sha512-vqdJ4nOjB3Q9O8SMtzbqn843mbqf+fOC3iYXdA88SNUujR70joGMZlyKE8LSQbLWhFnCm3SSjxWuHkgDpHOC+w==
   dependencies:
-    "@ledgerhq/errors" "^4.68.0"
-    "@ledgerhq/logs" "^4.64.0"
+    "@ledgerhq/errors" "^4.68.2"
+    "@ledgerhq/logs" "^4.68.2"
     rxjs "^6.5.2"
 
-"@ledgerhq/errors@^4.68.0":
-  version "4.68.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.68.0.tgz#311980a3e2b3d43b2f7381cb6b122f5a57e2539b"
-  integrity sha512-C+VjnCili9OgT4xaCpn0CYH+ri6BaJ4If7fFb5cXEj5WrahXBOLx6+tOWLaVXUIbBBaK+ia62+eSLecV2VMCqw==
+"@ledgerhq/errors@^4.68.2":
+  version "4.68.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.68.2.tgz#634f132c9c95935668ac2af90991ce57ebc44d63"
+  integrity sha512-JxMr4wj/9d7EQuTQ9khhJxQSzv5B6ZoLUm4spOY+FDfQo0ywx9qvD1NyBHHVzyn7uRtWvz/hOSfTSrlw2joM3w==
 
-"@ledgerhq/hw-app-eth@^4.68.1":
-  version "4.68.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.68.1.tgz#ba99a3d0655cc3c5efdb00002ddbdf6ba62b3a40"
-  integrity sha512-Vq0QMgZndjnf3zc6312tiX32Ktw0ddaL7d0P9S1XpP1Swx7EdjMYbxbGSdFD4iHiZ/ZVhfJNq1T7wEQ3K23RNA==
+"@ledgerhq/hw-app-eth@^4.68.2":
+  version "4.68.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.68.2.tgz#f8c0f19788b690261a8e42bcfb8d9057896e42b3"
+  integrity sha512-tmctn9t4x8ReKd03IxM/YSdZpVN9/UnnvNo8Kfqe5udlL9dqckC/4KnOENF0Ho896VkoN+CygH6PUqnV7TdNcA==
   dependencies:
-    "@ledgerhq/errors" "^4.68.0"
-    "@ledgerhq/hw-transport" "^4.68.0"
+    "@ledgerhq/errors" "^4.68.2"
+    "@ledgerhq/hw-transport" "^4.68.2"
 
-"@ledgerhq/hw-transport-u2f@^4.68.0":
-  version "4.68.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.68.0.tgz#aaf49ee9344ec36fbadec9cbb11c6e60c9f3c4f0"
-  integrity sha512-toe2IfmOKMr8D7AA4b49phQYuct2J4EfcIL7uP2VQxY90k36RxDlTllGv75Kkc9RwsH8dhU883afUMDdI7Et4g==
+"@ledgerhq/hw-transport-u2f@^4.68.2":
+  version "4.68.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.68.2.tgz#35a92b40da8e7a8f878ddb72723a807644c55b45"
+  integrity sha512-dWdoxorHISipDO/1PgaXgSnnkoKBqPFWzlAbn1+9gfbT2B/zzh3q1h6A3Zy6Yoc2BIqhUS3pgpZkBNqzUN47Ew==
   dependencies:
-    "@ledgerhq/errors" "^4.68.0"
-    "@ledgerhq/hw-transport" "^4.68.0"
-    "@ledgerhq/logs" "^4.64.0"
+    "@ledgerhq/errors" "^4.68.2"
+    "@ledgerhq/hw-transport" "^4.68.2"
+    "@ledgerhq/logs" "^4.68.2"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport@^4.68.0":
-  version "4.68.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.68.0.tgz#47a2f2de6bb4ad7003a4da1f2f61730bb86f2f28"
-  integrity sha512-+zvy8uI/4hB1lIjN/GBseCHG1hLDzySuJpcI4V4Zy5TPP8D/igw1F56nha5A8fRvzCCPl1zPQvTwg6Fj9lKdSw==
+"@ledgerhq/hw-transport@^4.68.2":
+  version "4.68.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.68.2.tgz#822f3f03e22372b7656451eb73e809d208cca119"
+  integrity sha512-erGPXBXavw4V5CP2aG/04guPKJKJl50+Z3kl3PbI4RwUijVeWsCw3UwEyEor01AANJ480CwfGB8vhcRt4hkGeQ==
   dependencies:
-    "@ledgerhq/devices" "^4.68.0"
-    "@ledgerhq/errors" "^4.68.0"
+    "@ledgerhq/devices" "^4.68.2"
+    "@ledgerhq/errors" "^4.68.2"
     events "^3.0.0"
 
-"@ledgerhq/logs@^4.64.0":
-  version "4.64.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.64.0.tgz#19a335e3f2d9188188437f8dabb06e0fd45b0052"
-  integrity sha512-NwgA7q1CXWMkqxoHVaSTk0gJUGbiBbWTM7Uod/Zz8EWNa1Ns0yHthCcSS279htP6oQplEaSppzsie5bcbwNApg==
+"@ledgerhq/logs@^4.68.2":
+  version "4.68.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.68.2.tgz#3ba74680927807f83d9f0bfd7da45f192d2c0893"
+  integrity sha512-iFwGIzPmAMDvxVLtTvBUo0DCWz8vVaD0C4IsprNaXbxu+AsDmlc9kO9CKLB5YFEZblKNNKqJMJDfKvg5brIpTw==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
This PR makes some changes to the `purser-ledger` and `purser-trezor` packages (necessitating some small changes to `purser-core`) such that the seeded signature values for the transaction to be signed (i.e. `r`, `s` and `v`) are not included. This is because `ethereumjs-tx` makes validations for EIP-155 that read these values (if present) and compare them with the chain ID, which was leading to validation errors for mainnet transactions.

**Changes**

* Remove initial `r`, `s` and `v` values from the unsigned transaction for Ledger and Trezor
* Add `bigNumberToHexString` util
* Update Ledger packages (minor version, no breaking changes)