### PR TITLE
Fix Metamask unit tests improperly mocked web3 global object

### DIFF
--- a/modules/tests/purser-metamask/staticMethods/signTransaction.test.js
+++ b/modules/tests/purser-metamask/staticMethods/signTransaction.test.js
@@ -66,6 +66,7 @@ global.web3 = {
       callback(undefined, mockedTransactionHash),
     ),
     getTransaction: jest.fn(() => Promise.resolve(mockedRawSignedTransaction)),
+    getTransactionReceipt: jest.fn(),
   },
 };
 


### PR DESCRIPTION
This is a simple PR that properly mocks the `web3` global object, inside the `purser-metamask` `signTransaction` unit test, to include all the methods required, even those that are being called internally.