### PR TITLE
Rename MetaMask public config store property

### DIFF
--- a/modules/node_modules/@colony/purser-metamask/helpers.js
+++ b/modules/node_modules/@colony/purser-metamask/helpers.js
@@ -58,16 +58,16 @@ export const detect = async (): Promise<boolean> => {
   if (!global.ethereum && global.web3) {
     if (
       !global.web3.currentProvider ||
-      !global.web3.currentProvider.publicConfigStore
+      !global.web3.currentProvider._publicConfigStore
     ) {
       throw new Error(messages.noInpageProvider);
     }
     /* eslint-disable-next-line no-underscore-dangle */
-    if (!global.web3.currentProvider.publicConfigStore._state) {
+    if (!global.web3.currentProvider._publicConfigStore._state) {
       throw new Error(messages.noProviderState);
     }
     /* eslint-disable-next-line no-underscore-dangle */
-    if (!global.web3.currentProvider.publicConfigStore._state.selectedAddress) {
+    if (!global.web3.currentProvider._publicConfigStore._state.selectedAddress) {
       throw new Error(messages.notEnabled);
     }
     return true;
@@ -159,7 +159,7 @@ export const setStateEventObserver = (
   }
   else {
     const {
-      publicConfigStore: { _events: stateEvents },
+      _publicConfigStore: { _events: stateEvents },
     }: MetamaskInpageProviderType = ethereum;
     stateEvents.update.push(observer);
   }

--- a/modules/node_modules/@colony/purser-metamask/helpers.js
+++ b/modules/node_modules/@colony/purser-metamask/helpers.js
@@ -58,6 +58,7 @@ export const detect = async (): Promise<boolean> => {
   if (!global.ethereum && global.web3) {
     if (
       !global.web3.currentProvider ||
+      /* eslint-disable-next-line no-underscore-dangle */
       !global.web3.currentProvider._publicConfigStore
     ) {
       throw new Error(messages.noInpageProvider);
@@ -66,8 +67,10 @@ export const detect = async (): Promise<boolean> => {
     if (!global.web3.currentProvider._publicConfigStore._state) {
       throw new Error(messages.noProviderState);
     }
-    /* eslint-disable-next-line no-underscore-dangle */
-    if (!global.web3.currentProvider._publicConfigStore._state.selectedAddress) {
+    if (
+      /* eslint-disable-next-line no-underscore-dangle */
+      !global.web3.currentProvider._publicConfigStore._state.selectedAddress
+    ) {
       throw new Error(messages.notEnabled);
     }
     return true;

--- a/modules/tests/mocks/@colony/purser-metamask/helpers.js
+++ b/modules/tests/mocks/@colony/purser-metamask/helpers.js
@@ -6,7 +6,7 @@ export const getInpageProvider = jest.fn(() => global.web3.currentProvider);
 
 export const setStateEventObserver = jest.fn(callback => {
   /* eslint-disable-next-line no-underscore-dangle */
-  global.web3.currentProvider.publicConfigStore._events.update.push(callback);
+  global.web3.currentProvider._publicConfigStore._events.update.push(callback);
 });
 
 /*
@@ -15,6 +15,6 @@ export const setStateEventObserver = jest.fn(callback => {
  */
 export const triggerUpdateStateEvents = newState =>
   /* eslint-disable-next-line no-underscore-dangle */
-  global.web3.currentProvider.publicConfigStore._events.update.map(callback =>
+  global.web3.currentProvider._publicConfigStore._events.update.map(callback =>
     callback(newState),
   );

--- a/modules/tests/mocks/web3.js
+++ b/modules/tests/mocks/web3.js
@@ -9,7 +9,7 @@ const mockedEvents = {
 
 const inPageProvider = {
   currentProvider: {
-    publicConfigStore: {
+    _publicConfigStore: {
       _events: mockedEvents,
       _state: mockedState,
     },

--- a/modules/tests/purser-metamask/accountChangeHook.test.js
+++ b/modules/tests/purser-metamask/accountChangeHook.test.js
@@ -20,7 +20,7 @@ jest.mock('@colony/purser-metamask/helpers', () =>
  */
 global.web3 = {
   currentProvider: {
-    publicConfigStore: {
+    _publicConfigStore: {
       _events: {
         update: [],
       },
@@ -50,7 +50,7 @@ describe('Metamask` Wallet Module', () => {
       await metamaskWallet.accountChangeHook(mockedCallback);
       expect(
         /* eslint-disable-next-line no-underscore-dangle */
-        global.web3.currentProvider.publicConfigStore._events.update,
+        global.web3.currentProvider._publicConfigStore._events.update,
       ).toContain(mockedCallback);
     });
     test('Catches if something goes wrong', async () => {

--- a/modules/tests/purser-metamask/class.test.js
+++ b/modules/tests/purser-metamask/class.test.js
@@ -73,7 +73,7 @@ global.web3 = {
     },
   },
   currentProvider: {
-    publicConfigStore: {
+    _publicConfigStore: {
       _events: {
         update: [],
       },
@@ -127,7 +127,7 @@ describe('Metamask` Wallet Module', () => {
        */
       const mockedMetamaskProvider = getInpageProvider();
       /* eslint-disable-next-line no-underscore-dangle */
-      mockedMetamaskProvider.publicConfigStore._events.update = [];
+      mockedMetamaskProvider._publicConfigStore._events.update = [];
       isEqual.mockClear();
       validateMetamaskState.mockClear();
       hexSequenceNormalizer.mockClear();
@@ -162,7 +162,7 @@ describe('Metamask` Wallet Module', () => {
       expect(setStateEventObserver).toHaveBeenCalled();
       expect(
         /* eslint-disable-next-line no-underscore-dangle */
-        mockedMetamaskProvider.publicConfigStore._events.update,
+        mockedMetamaskProvider._publicConfigStore._events.update,
       ).toHaveLength(1);
     });
     test('Validates the newly changed state', async () => {

--- a/modules/tests/purser-metamask/helpers/detect.test.js
+++ b/modules/tests/purser-metamask/helpers/detect.test.js
@@ -64,7 +64,7 @@ describe('Metamask` Wallet Module', () => {
        * Provider available, but no state
        */
       global.ethereum = undefined;
-      global.web3 = { currentProvider: { publicConfigStore: {} } };
+      global.web3 = { currentProvider: { _publicConfigStore: {} } };
       expect(detect()).rejects.toThrow();
       expect(detect()).rejects.toThrowError(
         new Error(messages.noProviderState),
@@ -75,7 +75,7 @@ describe('Metamask` Wallet Module', () => {
        * State available, but no enabled
        */
       global.ethereum = undefined;
-      global.web3 = { currentProvider: { publicConfigStore: { _state: {} } } };
+      global.web3 = { currentProvider: { _publicConfigStore: { _state: {} } } };
       expect(detect()).rejects.toThrow();
       expect(detect()).rejects.toThrowError(new Error(messages.notEnabled));
     });
@@ -100,7 +100,7 @@ describe('Metamask` Wallet Module', () => {
       global.ethereum = undefined;
       global.web3 = {
         currentProvider: {
-          publicConfigStore: {
+          _publicConfigStore: {
             _state: { selectedAddress: 'mocked-selected-address' },
           },
         },

--- a/modules/tests/purser-metamask/helpers/setStateEventObserver.test.js
+++ b/modules/tests/purser-metamask/helpers/setStateEventObserver.test.js
@@ -12,7 +12,7 @@ describe('Metamask` Wallet Module', () => {
        */
       global.web3 = {
         currentProvider: {
-          publicConfigStore: {
+          _publicConfigStore: {
             _events: {
               update: [],
             },
@@ -36,7 +36,7 @@ describe('Metamask` Wallet Module', () => {
        * Also reset the state event updates array
        */
       const {
-        publicConfigStore: { _events: stateEvents },
+        _publicConfigStore: { _events: stateEvents },
       } = helpers.default.getInpageProvider();
       stateEvents.update = [];
     });
@@ -46,7 +46,7 @@ describe('Metamask` Wallet Module', () => {
     });
     test('Adds the observer callback to the state events Array', async () => {
       const {
-        publicConfigStore: { _events: stateEvents },
+        _publicConfigStore: { _events: stateEvents },
       } = helpers.default.getInpageProvider();
       expect(stateEvents.update).toHaveLength(0);
       setStateEventObserver(() => {});


### PR DESCRIPTION
This PR makes `@purser/metamask` compatible with the latest MetaMask Ethereum provider, which was shipped to production everywhere today.

### Motivation

In MetaMask 8.0.x, `ethereum.publicConfigStore` is renamed `ethereum._publicConfigStore`, to better reflect its intended nature as an implementation detail and private property.

We've never, to my knowledge, publicized this property in our docs, but were made aware of its use in Colony, when a MetaMask user reported that colony.io had stopped working.

**The public config store is slated for removal in an upcoming update to MetaMask,** and should not be used by provider consumers for any reason. We recommend using the corresponding events detailed in [our (new and improved) documentation](https://docs.metamask.io/guide/ethereum-provider.html#events).

### Summary of Changes

- Rename every instance of `publicConfigStore` to `_publicConfigStore`, where the provider appears to be the MetaMask provider.
  - This may break your handling of old forks of MetaMask, depending on how you detect them. Detecting the latest MetaMask Ethereum provider can be done via `ethereum.isMetaMask && typeof ethereum.request === 'function'`.