### PR TITLE
Migrate metamask package to support Metamask v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "purser",
     "private": true,
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Interact with Ethereum wallets easily",
     "scripts": {
         "bootstrap": "lerna bootstrap",

--- a/packages/@purser/metamask/__tests__/helpers/detect.test.ts
+++ b/packages/@purser/metamask/__tests__/helpers/detect.test.ts
@@ -12,46 +12,70 @@ describe('Metamask` Wallet Module', () => {
       await expect(detect()).rejects.toThrow();
       await expect(detect()).rejects.toThrow(new Error(messages.noExtension));
     });
-    test('Checks if extension is unlocked', async () => {
+    test('Checks if provider is connected to chain', async () => {
       /*
        * Mock the `isUnlocked()` ethereum method
        */
-      const isUnlocked = jest.fn(async () => false);
+      const isConnected = jest.fn(() => false);
       testGlobal.ethereum = {
-        isUnlocked,
+        isConnected,
       };
       await expect(detect()).rejects.toThrow();
-      await expect(detect()).rejects.toThrow(new Error(messages.isLocked));
+      await expect(detect()).rejects.toThrow(new Error(messages.noProvider));
     });
-    test('Checks if extension is enabled', async () => {
+    test('Checks if the account is unlocked', async () => {
       /*
        * To reach this step, the extension already needs to be unlocked
        * (isUnlocked should return true)
        *
        * Mock the `isEnabled()` ethereum method
        */
-      const isUnlocked = jest.fn(async () => true);
-      const isEnabled = jest.fn(async () => false);
+      const isConnected = jest.fn(() => true);
+      const isUnlocked = jest.fn(async () => false);
       testGlobal.ethereum = {
-        isUnlocked,
-        isEnabled,
+        isConnected,
+        _metamask: {
+          isUnlocked,
+        },
       };
       await expect(detect()).rejects.toThrow();
-      await expect(detect()).rejects.toThrow(new Error(messages.notEnabled));
+      await expect(detect()).rejects.toThrow(new Error(messages.isLocked));
     });
-    test('Checks if the proxy has the in-page provider set', async () => {
-      testGlobal.ethereum = undefined;
-      await expect(detect()).rejects.toThrow(new Error(messages.noExtension));
+    test('Checks if we have permission to access the account', async () => {
+      /*
+       * To reach this step, the extension already needs to be unlocked
+       * (isUnlocked should return true)
+       *
+       * Mock the `isEnabled()` ethereum method
+       */
+      const request = jest.fn(async () => []);
+      const isConnected = jest.fn(() => true);
+      const isUnlocked = jest.fn(async () => true);
+      testGlobal.ethereum = {
+        isConnected,
+        request,
+        _metamask: {
+          isUnlocked,
+        },
+      };
+      await expect(detect()).rejects.toThrow();
+      await expect(detect()).rejects.toThrow(new Error(messages.notConnected));
     });
     test('Returns true if the extension is enabled', async () => {
       /*
        * Metamask is unlocked and enabled
        */
+      const request = jest.fn(async () => [
+        { parentCapability: 'eth_accounts' },
+      ]);
+      const isConnected = jest.fn(() => true);
       const isUnlocked = jest.fn(async () => true);
-      const isEnabled = jest.fn(async () => true);
       testGlobal.ethereum = {
-        isUnlocked,
-        isEnabled,
+        isConnected,
+        request,
+        _metamask: {
+          isUnlocked,
+        },
       };
       await expect(detect()).resolves.not.toThrow();
       const wasDetected = await detect();

--- a/packages/@purser/metamask/__tests__/open.test.ts
+++ b/packages/@purser/metamask/__tests__/open.test.ts
@@ -16,13 +16,12 @@ const mockedWarning = mocked(warning);
  * Mocked values
  */
 const mockedAddress = 'mocked-address';
-const mockedEnableMethod = jest.fn(() => [mockedAddress]);
+const mockedEnableMethod = jest.fn(async () => [mockedAddress]);
 
 describe('Metamask` Wallet Module', () => {
   beforeEach(() => {
     testGlobal.ethereum = {
-      enable: mockedEnableMethod,
-      on: jest.fn(),
+      request: mockedEnableMethod,
     };
   });
   afterEach(() => {
@@ -30,7 +29,7 @@ describe('Metamask` Wallet Module', () => {
     mockedEnableMethod.mockClear();
   });
   describe('`open()` static method', () => {
-    test('Start in EIP-1102 mode', async () => {
+    test('Request accounts', async () => {
       await open();
       /*
        * Enabled the account

--- a/packages/@purser/metamask/package.json
+++ b/packages/@purser/metamask/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@purser/metamask",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "A javascript library to interact with a Metamask based Ethereum wallet",
     "license": "MIT",
     "main": "lib/index.js",

--- a/packages/@purser/metamask/src/helpers.ts
+++ b/packages/@purser/metamask/src/helpers.ts
@@ -1,6 +1,6 @@
 import { helpers as messages } from './messages';
 
-import { AccountsChangedCallback } from './types';
+import { AccountsChangedCallback, ObservableEvents } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const anyGlobal: any = global;
@@ -101,7 +101,8 @@ export const methodCaller = async <T>(
  */
 export const setStateEventObserver = (
   callback: AccountsChangedCallback,
+  observableEvent: ObservableEvents = 'accountsChanged',
 ): void => {
   const { ethereum } = anyGlobal;
-  ethereum.on('accountsChanged', callback);
+  ethereum.on(observableEvent, callback);
 };

--- a/packages/@purser/metamask/src/helpers.ts
+++ b/packages/@purser/metamask/src/helpers.ts
@@ -20,39 +20,37 @@ export const detect = async (): Promise<boolean> => {
    * Modern Metamask Version
    */
   if (anyGlobal.ethereum) {
+    const {
+      ethereum: { _metamask, request },
+      ethereum,
+    } = anyGlobal;
     /*
-     * @NOTE This is a temporary failsafe check, since Metmask is running an
-     * intermediate version which, while it contains most of the `ethereum`
-     * global object, it doesn't contain this helper method
-     *
-     * @TODO Remove legacy metmask object availability check
-     * After an adequate amount of time has passed
+     * Check that the provider is connected to the chain
      */
-    if (
-      anyGlobal.ethereum.isUnlocked &&
-      !(await anyGlobal.ethereum.isUnlocked())
-    ) {
+    if (!ethereum.isConnected()) {
+      throw new Error(messages.noProvider);
+    }
+    /*
+     * Check if the account is unlocked
+     *
+     * @NOTE we just assume the required methods exist on the metamask provider
+     * otherwise we'll get right back to "support legacy metamask hell"
+     */
+    if (!(await _metamask.isUnlocked())) {
       throw new Error(messages.isLocked);
     }
     /*
-     * @NOTE This is a temporary failsafe check, since Metmask is running an
-     * intermediate version which, while it contains most of the `ethereum`
-     * global object, it doesn't contain this helper method
-     *
-     * @TODO Remove legacy metmask object availability check
-     * After an adequate amount of time has passed
+     * If we don't have the `eth_accounts` permissions it means that we don't have
+     * account access
      */
+    const permissions = await request({ method: 'wallet_getPermissions' });
     if (
-      anyGlobal.ethereum.isEnabled &&
-      !(await anyGlobal.ethereum.isEnabled())
+      !permissions.length ||
+      !permissions[0] ||
+      permissions[0].parentCapability !== 'eth_accounts'
     ) {
-      throw new Error(messages.notEnabled);
+      throw new Error(messages.notConnected);
     }
-    /*
-     * @NOTE If the `isUnlocked` and the `isEnabled` methods are not available
-     * it means we are running the pre-release version of Metamask, just prior
-     * to the EIP-1102 update, so we just ignore those checks
-     */
     return true;
   }
   throw new Error(messages.noExtension);

--- a/packages/@purser/metamask/src/helpers.ts
+++ b/packages/@purser/metamask/src/helpers.ts
@@ -20,10 +20,7 @@ export const detect = async (): Promise<boolean> => {
    * Modern Metamask Version
    */
   if (anyGlobal.ethereum) {
-    const {
-      ethereum: { _metamask, request },
-      ethereum,
-    } = anyGlobal;
+    const { ethereum } = anyGlobal;
     /*
      * Check that the provider is connected to the chain
      */
@@ -36,14 +33,17 @@ export const detect = async (): Promise<boolean> => {
      * @NOTE we just assume the required methods exist on the metamask provider
      * otherwise we'll get right back to "support legacy metamask hell"
      */
-    if (!(await _metamask.isUnlocked())) {
+    // eslint-disable-next-line no-underscore-dangle
+    if (!(await ethereum._metamask.isUnlocked())) {
       throw new Error(messages.isLocked);
     }
     /*
      * If we don't have the `eth_accounts` permissions it means that we don't have
      * account access
      */
-    const permissions = await request({ method: 'wallet_getPermissions' });
+    const permissions = await ethereum.request({
+      method: 'wallet_getPermissions',
+    });
     if (
       !permissions.length ||
       !permissions[0] ||

--- a/packages/@purser/metamask/src/index.ts
+++ b/packages/@purser/metamask/src/index.ts
@@ -79,7 +79,6 @@ export const detect = async (): Promise<boolean> => detectHelper();
  * @method accountChangeHook
  *
  * @param {Function} callback Function to add the state events update array
- * It receives the state object as an only argument
  *
  * @return {Promise<void>} Does not return noting
  */
@@ -94,6 +93,40 @@ export const accountChangeHook = async (
   detectHelper();
   try {
     return setStateEventObserver(callback);
+  } catch (error) {
+    /*
+     * If this throws/catches here it means something very weird is going on.
+     * `detect()` should catch anything that're directly related to Metamask's functionality,
+     * but if that passes and we have to catch it here, it means some underlying APIs
+     * might have changed, and this will be very hard to debug
+     */
+    throw new Error(messages.cannotAddHook);
+  }
+};
+
+/**
+ * Hook into Metamask's state events observers array to be able to act on account
+ * changes from the UI
+ *
+ * It's a wrapper around the `setStateEventObserver()` helper method
+ *
+ * @method chainChangeHook
+ *
+ * @param {Function} callback Function to add the state events update array
+ *
+ * @return {Promise<void>} Does not return noting
+ */
+export const chainChangeHook = async (
+  callback: AccountsChangedCallback,
+): Promise<void> => {
+  /*
+   * If detect fails, it will throw, with a message explaining the problem
+   * (Most likely Metamask will be locked, so we won't be able to get to
+   * the state observer via the in-page provider)
+   */
+  detectHelper();
+  try {
+    return setStateEventObserver(callback, 'chainChanged');
   } catch (error) {
     /*
      * If this throws/catches here it means something very weird is going on.

--- a/packages/@purser/metamask/src/index.ts
+++ b/packages/@purser/metamask/src/index.ts
@@ -26,6 +26,7 @@ export const messages = staticMethods;
  */
 export const open = async (): Promise<MetaMaskWallet> => {
   let addressAfterEnable: string;
+  detectHelper();
   try {
     /*
      * See: https://eips.ethereum.org/EIPS/eip-1102
@@ -33,7 +34,10 @@ export const open = async (): Promise<MetaMaskWallet> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const anyGlobal: any = global;
     if (anyGlobal.ethereum) {
-      [addressAfterEnable] = await anyGlobal.ethereum.enable();
+      const { ethereum } = anyGlobal;
+      [addressAfterEnable] = await ethereum.request({
+        method: 'eth_requestAccounts',
+      });
     }
     return methodCaller(() => {
       return new MetaMaskWallet({

--- a/packages/@purser/metamask/src/messages.ts
+++ b/packages/@purser/metamask/src/messages.ts
@@ -32,8 +32,9 @@ export const helpers = {
   noExtension:
     "Could not detect the Metamask extension. Ensure that it's enabled",
   isLocked: "Metamask's instance is locked. Please unlock it from the UI",
-  notEnabled:
-    'The Metmask extension instance has not been enabled on this page. Please use the `open()` method to do so.',
+  notConnected:
+    'The Metmask account is not connected to the current domain. Please manually connected from the extension itself',
+  noProvider: 'The Metmask provider is not connected to the chain.',
   /*
    * Legacy Metamask Version
    *

--- a/packages/@purser/metamask/src/types.ts
+++ b/packages/@purser/metamask/src/types.ts
@@ -9,3 +9,10 @@ export interface SignMessageObject {
   message: string;
   messageData: string | Uint8Array;
 }
+
+export type ObservableEvents =
+  | 'accountsChanged'
+  | 'chainChanged'
+  | 'connect'
+  | 'disconnect'
+  | 'message';

--- a/packages/@purser/signer-ethers/package.json
+++ b/packages/@purser/signer-ethers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@purser/signer-ethers",
-    "version": "1.0.1-alpha.0",
+    "version": "1.0.1",
     "description": "A signer to use purser with ethers.js",
     "license": "MIT",
     "main": "lib/index.js",


### PR DESCRIPTION
This PR changes the `metamask` package of this lib to support the recently deprecated Metamask API and updates according to the migration guide put out by metamask: https://docs.metamask.io/guide/provider-migration.html