### PR TITLE
Fix `await on null` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ Purser is a monorepo consisting of a collection of Ethereum wallet libraries:
 - [`@purser/software`](https://github.com/JoinColony/purser/blob/master/packages/@purser/software): A `javascript` library to interact with a software Ethereum wallet, based on the [ethers.js](https://github.com/ethers-io/ethers.js/) library.
 - [`@purser/signer-ethers`](https://github.com/JoinColony/purser/blob/master/packages/@purser/signer-ethers): An implementation of an [ethers](https://github.com/ethers-io/ethers.js/) signer to use with any of the purser compatible wallets.
 
+### To build and release
+
+In the root directory:
+
+```
+npm i
+npm run bootstrap
+npm run build
+npm run publish
+```
+
+To clean detritus and reset the repository:
+
+```
+./node_modules/.bin/lerna clean
+npm run bootstrap
+```
+
 ### The future
 
 We plan to add support more hardware wallets and other features that will make wallet interactions even easier. Stay tuned!

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
         "test": "npm run lint && npm run typecheck && jest",
         "lint": "lerna run lint",
         "lint:fix": "lerna run lint -- -- --fix",
-        "publish": "lerna publish",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm test && npm run build"
+        "publish": "npm run test && npm run build && lerna publish",
+        "typecheck": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/@purser/__mocks__/ethers/utils/index.ts
+++ b/packages/@purser/__mocks__/ethers/utils/index.ts
@@ -1,5 +1,7 @@
 export const bigNumberify = jest.fn((value) => value);
 
+export const poll = jest.fn(() => '');
+
 export const verifyMessage = jest.fn((message, signature) => {
   if (!message || !signature) {
     throw new Error();

--- a/packages/@purser/signer-ethers/__tests__/EthersSigner.test.ts
+++ b/packages/@purser/signer-ethers/__tests__/EthersSigner.test.ts
@@ -1,4 +1,5 @@
 import { Signer } from 'ethers';
+import { poll } from 'ethers/utils';
 import { BaseProvider } from 'ethers/providers/base-provider';
 import { mocked } from 'ts-jest/utils';
 
@@ -111,6 +112,7 @@ describe('`Core` Module', () => {
         value: bigNumber(4),
       });
       expect(mockedProvider.sendTransaction).toHaveBeenCalled();
+      expect(poll).toHaveBeenCalled();
     });
   });
 });

--- a/packages/@purser/signer-ethers/package-lock.json
+++ b/packages/@purser/signer-ethers/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purser/signer-ethers",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/@purser/signer-ethers/package.json
+++ b/packages/@purser/signer-ethers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@purser/signer-ethers",
-    "version": "1.0.0",
+    "version": "1.0.1-alpha.0",
     "description": "A signer to use purser with ethers.js",
     "license": "MIT",
     "main": "lib/index.js",

--- a/packages/@purser/signer-ethers/src/EthersSigner.ts
+++ b/packages/@purser/signer-ethers/src/EthersSigner.ts
@@ -146,10 +146,13 @@ export default class EthersSigner extends Signer {
     // transaction too quickly causing us to wait indefinitely, therefore, we
     // need to try getting the transaction and then, if that fails, we need to
     // try getting the transaction using `waitForTransaction`.
-    const transaction = await this.provider.getTransaction(txHash);
+    let transaction = await this.provider.getTransaction(txHash);
     if (!transaction) {
       await this.provider.waitForTransaction(txHash);
     }
-    return this.provider.getTransaction(txHash);
+    while (!transaction) {
+      transaction = await this.provider.getTransaction(txHash);
+    }
+    return transaction;
   }
 }

--- a/packages/@purser/signer-ethers/src/EthersSigner.ts
+++ b/packages/@purser/signer-ethers/src/EthersSigner.ts
@@ -1,5 +1,5 @@
 import { Signer } from 'ethers';
-import { BigNumber, BigNumberish, bigNumberify } from 'ethers/utils';
+import { BigNumber, BigNumberish, bigNumberify, poll } from 'ethers/utils';
 import {
   Provider,
   TransactionRequest,
@@ -150,9 +150,17 @@ export default class EthersSigner extends Signer {
     if (!transaction) {
       await this.provider.waitForTransaction(txHash);
     }
-    while (!transaction) {
-      transaction = await this.provider.getTransaction(txHash);
-    }
-    return transaction;
+
+    return poll(async() => {
+      const response = await this.provider.getTransaction(txHash);
+      // If this request goes wrong, it returns null. But poll specifically
+      // retries on undefined...
+      if (response == null) {
+        return undefined;
+      }
+      return response;
+    }, {
+      timeout: 60000 // One minute
+    });
   }
 }

--- a/packages/@purser/signer-ethers/src/EthersSigner.ts
+++ b/packages/@purser/signer-ethers/src/EthersSigner.ts
@@ -146,21 +146,24 @@ export default class EthersSigner extends Signer {
     // transaction too quickly causing us to wait indefinitely, therefore, we
     // need to try getting the transaction and then, if that fails, we need to
     // try getting the transaction using `waitForTransaction`.
-    let transaction = await this.provider.getTransaction(txHash);
+    const transaction = await this.provider.getTransaction(txHash);
     if (!transaction) {
       await this.provider.waitForTransaction(txHash);
     }
 
-    return poll(async() => {
-      const response = await this.provider.getTransaction(txHash);
-      // If this request goes wrong, it returns null. But poll specifically
-      // retries on undefined...
-      if (response == null) {
-        return undefined;
-      }
-      return response;
-    }, {
-      timeout: 60000 // One minute
-    });
+    return poll(
+      async () => {
+        const response = await this.provider.getTransaction(txHash);
+        // If this request goes wrong, it returns null. But poll specifically
+        // retries on undefined...
+        if (response == null) {
+          return undefined;
+        }
+        return response;
+      },
+      {
+        timeout: 60000, // One minute
+      },
+    );
   }
 }


### PR DESCRIPTION
This PR fixes the `await on null` issues we were seeing using Infura's provider.

This was done by intercepting the response and in case it's `null`, just return `undefined` since `poll()` will retry on an undefined response.