### PR TITLE
Better Metamask Locked State Detection

### DIFF
--- a/packages/@purser/metamask/package-lock.json
+++ b/packages/@purser/metamask/package-lock.json
@@ -4,29 +4,182 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@purser/core": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@purser/core/-/core-3.0.0.tgz",
+			"integrity": "sha512-zYtJ5IjdRFfr4VECH1AFB9U2SvGcRJa/BSFsw23yO/mlqrk17wuF+07mSzPNU24X1bq6fvK0/VtQDtIug9fkBg==",
+			"requires": {
+				"bn.js": "^5.1.1",
+				"ethereumjs-common": "^1.5.0",
+				"ethereumjs-util": "^6.2.0",
+				"hdkey": "^1.1.2"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+				}
+			}
+		},
+		"@types/bn.js": {
+			"version": "4.11.6",
+			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+			"integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "16.9.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+			"integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
+		},
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/secp256k1": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+			"integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"aes-js": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
 			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
 			"dev": true
 		},
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"bip66": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"blakejs": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
+			"integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
+		},
 		"bn.js": {
 			"version": "4.11.9",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-			"dev": true
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
 		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"requires": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"requires": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"drbg.js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+			"requires": {
+				"browserify-aes": "^1.0.6",
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4"
+			}
 		},
 		"elliptic": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
 			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -35,6 +188,68 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			},
+			"dependencies": {
+				"hash.js": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+					"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.1"
+					}
+				},
+				"scrypt-js": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				}
+			}
+		},
+		"ethereumjs-common": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+			"integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
+		},
+		"ethereumjs-util": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+			"requires": {
+				"@types/bn.js": "^4.11.3",
+				"bn.js": "^4.11.0",
+				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
+				"ethjs-util": "0.1.6",
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethers": {
@@ -54,21 +269,79 @@
 				"xmlhttprequest": "1.8.0"
 			}
 		},
+		"ethjs-util": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+			"requires": {
+				"is-hex-prefixed": "1.0.0",
+				"strip-hex-prefix": "1.0.0"
+			}
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"requires": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+		},
+		"hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"requires": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			}
+		},
 		"hash.js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"hdkey": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
+			"integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
+			"requires": {
+				"bs58check": "^2.1.2",
+				"safe-buffer": "^5.1.1",
+				"secp256k1": "^3.0.1"
+			},
+			"dependencies": {
+				"secp256k1": {
+					"version": "3.8.0",
+					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+					"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+					"requires": {
+						"bindings": "^1.5.0",
+						"bip66": "^1.1.5",
+						"bn.js": "^4.11.8",
+						"create-hash": "^1.2.0",
+						"drbg.js": "^1.0.1",
+						"elliptic": "^6.5.2",
+						"nan": "^2.14.0",
+						"safe-buffer": "^5.1.2"
+					}
+				}
 			}
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -78,8 +351,12 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-hex-prefixed": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
 		},
 		"js-sha3": {
 			"version": "0.5.7",
@@ -87,17 +364,102 @@
 			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
 			"dev": true
 		},
+		"keccak": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+			"integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+			"requires": {
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0",
+				"readable-stream": "^3.6.0"
+			}
+		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
+		"nan": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-gyp-build": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+			"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+		},
+		"pbkdf2": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+			"integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
+		"rlp": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+			"requires": {
+				"bn.js": "^4.11.1"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"scrypt-js": {
 			"version": "2.0.4",
@@ -105,11 +467,51 @@
 			"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
 			"dev": true
 		},
+		"secp256k1": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+			"requires": {
+				"elliptic": "^6.5.2",
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
 			"integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
 			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"strip-hex-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+			"requires": {
+				"is-hex-prefixed": "1.0.0"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "2.0.1",

--- a/packages/@purser/metamask/package-lock.json
+++ b/packages/@purser/metamask/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purser/metamask",
-	"version": "3.1.1",
+	"version": "3.1.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/@purser/metamask/package.json
+++ b/packages/@purser/metamask/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@purser/metamask",
-    "version": "3.1.1",
+    "version": "3.1.2-alpha.0",
     "description": "A javascript library to interact with a Metamask based Ethereum wallet",
     "license": "MIT",
     "main": "lib/index.js",

--- a/packages/@purser/metamask/package.json
+++ b/packages/@purser/metamask/package.json
@@ -45,6 +45,7 @@
         "ethers": "^4.0.47"
     },
     "devDependencies": {
+        "@types/node": "^16.9.4",
         "ethers": "^4.0.47"
     }
 }

--- a/packages/@purser/metamask/src/index.ts
+++ b/packages/@purser/metamask/src/index.ts
@@ -9,7 +9,7 @@ import {
 
 import { staticMethods } from './messages';
 
-import { AccountsChangedCallback } from './types';
+import { AccountsChangedCallback, EthereumRequestMethods } from './types';
 
 // Export some helpful types and utils
 export type { MetaMaskWallet, PurserWallet };
@@ -36,7 +36,7 @@ export const open = async (): Promise<MetaMaskWallet> => {
     if (anyGlobal.ethereum) {
       const { ethereum } = anyGlobal;
       [addressAfterEnable] = await ethereum.request({
-        method: 'eth_requestAccounts',
+        method: EthereumRequestMethods.RequestAccounts,
       });
     }
     return methodCaller(() => {

--- a/packages/@purser/metamask/src/types.ts
+++ b/packages/@purser/metamask/src/types.ts
@@ -1,3 +1,5 @@
+import type { EventEmitter } from 'events';
+
 export type AccountsChangedCallback = (accounts: string[]) => void;
 
 export interface MetamaskWalletConstructorArgumentsType {
@@ -16,3 +18,28 @@ export type ObservableEvents =
   | 'connect'
   | 'disconnect'
   | 'message';
+
+interface EthereumRequestArguments {
+  method: string;
+  params?: unknown[] | object;
+}
+
+export interface MetamaskEthereumGlobal {
+  isConnected: () => boolean;
+  request<R>(args: EthereumRequestArguments): Promise<R>;
+  on: (eventName: ObservableEvents, listener: (any) => void) => EventEmitter;
+
+  /*
+   * Experimental part of the Provider API
+   * https://docs.metamask.io/guide/ethereum-provider.html#experimental-api
+   */
+  _metamask: {
+    isUnlocked: () => Promise<boolean>;
+  };
+}
+
+export enum EthereumRequestMethods {
+  Accounts = 'eth_accounts',
+  RequestAccounts = 'eth_requestAccounts',
+  WalletPermissions = 'wallet_getPermissions',
+}

--- a/packages/@purser/signer-ethers/package-lock.json
+++ b/packages/@purser/signer-ethers/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purser/signer-ethers",
-	"version": "1.0.2",
+	"version": "1.0.3-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/@purser/signer-ethers/package.json
+++ b/packages/@purser/signer-ethers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@purser/signer-ethers",
-    "version": "1.0.2",
+    "version": "1.0.3-alpha.0",
     "description": "A signer to use purser with ethers.js",
     "license": "MIT",
     "main": "lib/index.js",

--- a/packages/@purser/signer-ethers/src/EthersSigner.ts
+++ b/packages/@purser/signer-ethers/src/EthersSigner.ts
@@ -28,7 +28,7 @@ const transformData = (data: BigNumberish): string => {
   if (data instanceof BigNumber) {
     return data.toHexString();
   }
-  return Buffer.from(data).toString('hex');
+  return Buffer.from(data as Array<number>).toString('hex');
 };
 
 /**


### PR DESCRIPTION
This PR improves Metamask's locked state detection by manually checking for the experimental `isUnlocked` value, as well as trying to access the accounts, in a sort of double blind test.

This change was made to overcome the `isUnlocked` to refresh it's returned value instantly. It needs a page refresh until it shows the new (unlocked) state.